### PR TITLE
IS-2472: GET kandidat for person

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/ISenOppfolgingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ISenOppfolgingRepository.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.application
 
+import no.nav.syfo.domain.Personident
 import no.nav.syfo.domain.SenOppfolgingKandidat
 import no.nav.syfo.domain.SenOppfolgingSvar
 import no.nav.syfo.domain.SenOppfolgingVurdering
@@ -13,4 +14,5 @@ interface ISenOppfolgingRepository {
     fun getKandidat(kandidatUuid: UUID): SenOppfolgingKandidat?
     fun getUnpublishedKandidater(): List<SenOppfolgingKandidat>
     fun setPublished(kandidatUuid: UUID)
+    fun getKandidater(personident: Personident): List<SenOppfolgingKandidat>
 }

--- a/src/main/kotlin/no/nav/syfo/application/SenOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/SenOppfolgingService.kt
@@ -58,4 +58,6 @@ class SenOppfolgingService(
                 }
         }
     }
+
+    fun getKandidater(personident: Personident): List<SenOppfolgingKandidat> = senOppfolgingRepository.getKandidater(personident = personident)
 }


### PR DESCRIPTION
Frontend trenger api for å hente kandidat(er) for en person for å ferdigbehandle/vurdere en gitt kandidat. Returnerer foreløpig bare en liste med alle kandidat-rader for en personident sortert med nyeste først. 
Til å begynne med kan frontend bare bruke første element og vise knapp for å ferdigbehandle hvis kandidaten ikke er ferdigbehandlet.