### PR TITLE
Publiserer kandidater som er varslet, men ikke svart

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/SenOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/application/SenOppfolgingService.kt
@@ -71,6 +71,7 @@ class SenOppfolgingService(
     fun publishUnpublishedKandidatStatus(): List<Result<SenOppfolgingKandidat>> {
         val unpublishedKandidatStatuser = senOppfolgingRepository.getUnpublishedKandidatStatuser()
         return unpublishedKandidatStatuser
+            .filter { kandidat -> kandidat.svar != null || kandidat.isVarsletForMinstTiDagerSiden() }
             .map { kandidat ->
                 kandidatStatusProducer.send(kandidat = kandidat).map {
                     val latestVurdering = it.getLatestVurdering()

--- a/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingKandidat.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.domain
 
+import no.nav.syfo.util.isMoreThanDaysAgo
 import java.time.OffsetDateTime
 import java.util.*
 
@@ -42,6 +43,8 @@ data class SenOppfolgingKandidat private constructor(
     fun isFerdigbehandlet(): Boolean = status == SenOppfolgingStatus.FERDIGBEHANDLET
 
     fun getLatestVurdering(): SenOppfolgingVurdering? = vurderinger.maxByOrNull { it.createdAt }
+
+    fun isVarsletForMinstTiDagerSiden() = varselAt != null && varselAt isMoreThanDaysAgo 10
 
     companion object {
         fun createFromDatabase(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/SenOppfolgingRepository.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/database/repository/SenOppfolgingRepository.kt
@@ -222,10 +222,8 @@ class SenOppfolgingRepository(private val database: DatabaseInterface) : ISenOpp
             """
                 SELECT kandidat.* 
                 FROM SEN_OPPFOLGING_KANDIDAT kandidat
-                WHERE svar_at IS NOT NULL AND (
-                    kandidat.published_at IS NULL OR EXISTS (
-                        SELECT 1 FROM SEN_OPPFOLGING_VURDERING vurdering WHERE vurdering.kandidat_id = kandidat.id AND vurdering.published_at IS NULL
-                    )
+                WHERE kandidat.published_at IS NULL OR EXISTS (
+                    SELECT 1 FROM SEN_OPPFOLGING_VURDERING vurdering WHERE vurdering.kandidat_id = kandidat.id AND vurdering.published_at IS NULL
                 )
                 ORDER BY kandidat.created_at ASC
             """

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -11,3 +11,5 @@ fun nowUTC(): OffsetDateTime = OffsetDateTime.now(defaultZoneOffset)
 fun LocalDateTime.toOffsetDateTimeUTC(): OffsetDateTime = this.atZone(osloTimeZone).withZoneSameInstant(defaultZoneOffset).toOffsetDateTime()
 
 fun OffsetDateTime.millisekundOpplosning(): OffsetDateTime = this.truncatedTo(ChronoUnit.MILLIS)
+
+infix fun OffsetDateTime.isMoreThanDaysAgo(days: Long): Boolean = this.isBefore(OffsetDateTime.now().minusDays(days))


### PR DESCRIPTION
Tilpasset cronjob som publiserer kandidater til å publisere de som har svart eller de som ikke har svart og det har gått ti dager siden varsel slik at de dukker opp i oversikten.