### PR TITLE
IS-2687: Extend DTO with varselAt and svar

### DIFF
--- a/src/main/kotlin/no/nav/syfo/api/model/SenOppfolgingKandidatResponseDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/api/model/SenOppfolgingKandidatResponseDTO.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.api.model
 
+import no.nav.syfo.domain.OnskerOppfolging
 import no.nav.syfo.domain.SenOppfolgingKandidat
 import no.nav.syfo.domain.SenOppfolgingStatus
 import no.nav.syfo.domain.VurderingType
@@ -11,6 +12,8 @@ data class SenOppfolgingKandidatResponseDTO(
     val createdAt: LocalDateTime,
     val personident: String,
     val status: SenOppfolgingStatus,
+    val varselAt: LocalDateTime?,
+    val svar: SvarResponseDTO?,
     val vurderinger: List<SenOppfolgingVurderingResponseDTO>,
 )
 
@@ -22,11 +25,23 @@ data class SenOppfolgingVurderingResponseDTO(
     val createdAt: LocalDateTime,
 )
 
+data class SvarResponseDTO(
+    val svarAt: LocalDateTime,
+    val onskerOppfolging: OnskerOppfolging,
+)
+
 fun SenOppfolgingKandidat.toResponseDTO(): SenOppfolgingKandidatResponseDTO = SenOppfolgingKandidatResponseDTO(
     uuid = this.uuid,
     createdAt = this.createdAt.toLocalDateTime(),
     personident = this.personident.value,
     status = this.status,
+    varselAt = this.varselAt?.toLocalDateTime(),
+    svar = this.svar?.let {
+        SvarResponseDTO(
+            svarAt = it.svarAt.toLocalDateTime(),
+            onskerOppfolging = it.onskerOppfolging,
+        )
+    },
     vurderinger = this.vurderinger.map {
         SenOppfolgingVurderingResponseDTO(
             uuid = it.uuid,

--- a/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingKandidat.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.domain
 
+import no.nav.syfo.util.nowUTC
 import no.nav.syfo.util.isMoreThanDaysAgo
 import java.time.OffsetDateTime
 import java.util.*
@@ -22,7 +23,7 @@ data class SenOppfolgingKandidat private constructor(
     ) : this(
         uuid = UUID.randomUUID(),
         personident = personident,
-        createdAt = OffsetDateTime.now(),
+        createdAt = nowUTC(),
         varselAt = varselAt,
         varselId = varselId,
         svar = null,

--- a/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
+++ b/src/main/kotlin/no/nav/syfo/util/DateUtil.kt
@@ -13,3 +13,5 @@ fun LocalDateTime.toOffsetDateTimeUTC(): OffsetDateTime = this.atZone(osloTimeZo
 fun OffsetDateTime.millisekundOpplosning(): OffsetDateTime = this.truncatedTo(ChronoUnit.MILLIS)
 
 infix fun OffsetDateTime.isMoreThanDaysAgo(days: Long): Boolean = this.isBefore(OffsetDateTime.now().minusDays(days))
+
+fun LocalDateTime.millisekundOpplosning(): LocalDateTime = this.truncatedTo(ChronoUnit.MILLIS)


### PR DESCRIPTION
Utvider kandidat-response-dtoen med data om svar og når kandidaten ble varslet. Vi trenger dette etter hvert i bulk-endepunktet for å vise i oversikten og inne på enkeltperson for å vise når kandidaten ble varslet. Vi kan også bruke dette til å styre om rød prikk/vurdering-skjema skal vises inne på enkeltperson.