### PR TITLE
IS-2717: Lag ny kandidat ved nytt svar

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingVurdering.kt
@@ -44,6 +44,9 @@ data class SenOppfolgingVurdering private constructor(
     }
 }
 
+fun SenOppfolgingVurdering.isFerdigBehandlet() =
+    this.type == VurderingType.FERDIGBEHANDLET
+
 enum class VurderingType {
     FERDIGBEHANDLET,
 }

--- a/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingVurdering.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/SenOppfolgingVurdering.kt
@@ -44,9 +44,6 @@ data class SenOppfolgingVurdering private constructor(
     }
 }
 
-fun SenOppfolgingVurdering.isFerdigBehandlet() =
-    this.type == VurderingType.FERDIGBEHANDLET
-
 enum class VurderingType {
     FERDIGBEHANDLET,
 }

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingSvarConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingSvarConsumer.kt
@@ -51,18 +51,14 @@ class SenOppfolgingSvarConsumer(private val senOppfolgingService: SenOppfolgingS
         }
 
         val onskerOppfolging = senOppfolgingSvarRecord.response.toOnskerOppfolging()
-        if (kandidat.svar != null) {
-            log.error("Duplicate svar $onskerOppfolging received for kandidat ${kandidat.uuid}")
-        } else {
-            senOppfolgingService.addSvar(
-                kandidat = kandidat,
-                svarAt = senOppfolgingSvarRecord.createdAt.toOffsetDateTimeUTC(),
-                onskerOppfolging = onskerOppfolging,
-            )
-            when (onskerOppfolging) {
-                OnskerOppfolging.JA -> Metrics.COUNT_KAFKA_CONSUMER_SEN_OPPFOLGING_SVAR_KANDIDAT_ONSKER_OPPFOLGING.increment()
-                OnskerOppfolging.NEI -> Metrics.COUNT_KAFKA_CONSUMER_SEN_OPPFOLGING_SVAR_KANDIDAT_ONSKER_IKKE_OPPFOLGING.increment()
-            }
+        senOppfolgingService.addSvar(
+            kandidat = kandidat,
+            svarAt = senOppfolgingSvarRecord.createdAt.toOffsetDateTimeUTC(),
+            onskerOppfolging = onskerOppfolging,
+        )
+        when (onskerOppfolging) {
+            OnskerOppfolging.JA -> Metrics.COUNT_KAFKA_CONSUMER_SEN_OPPFOLGING_SVAR_KANDIDAT_ONSKER_OPPFOLGING.increment()
+            OnskerOppfolging.NEI -> Metrics.COUNT_KAFKA_CONSUMER_SEN_OPPFOLGING_SVAR_KANDIDAT_ONSKER_IKKE_OPPFOLGING.increment()
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingSvarConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingSvarConsumer.kt
@@ -36,13 +36,15 @@ class SenOppfolgingSvarConsumer(private val senOppfolgingService: SenOppfolgingS
         val recentKandidat = senOppfolgingService.findRecentKandidatFromPersonIdent(
             personident = Personident(senOppfolgingSvarRecord.personIdent),
         )
-        val kandidat = if (kandidatForVarsel != null) {
+        val kandidat = if (kandidatForVarsel != null && !kandidatForVarsel.isFerdigbehandlet()) {
             kandidatForVarsel
-        } else if (recentKandidat != null) {
+        } else if (recentKandidat != null && !recentKandidat.isFerdigbehandlet()) {
             recentKandidat
         } else {
             senOppfolgingService.createKandidat(
                 personident = Personident(senOppfolgingSvarRecord.personIdent),
+                varselAt = kandidatForVarsel?.varselAt,
+                varselId = kandidatForVarsel?.varselId,
             ).also {
                 Metrics.COUNT_KAFKA_CONSUMER_SEN_OPPFOLGING_SVAR_KANDIDAT_CREATED.increment()
             }


### PR DESCRIPTION
Løsningen innebærer at det alltid lages en ny kandidat når det kommer et svar der varselId'en peker til en kandidat som er ferdig behandlet. Dette gjelder både når det har kommet svar og i de tilfellene der veileder har behandlet oppgave knyttet til manglende svar.