### PR TITLE
IS-2757: Delete more duplicates

### DIFF
--- a/src/main/resources/db/migration/V2_3__delete_duplicates.sql
+++ b/src/main/resources/db/migration/V2_3__delete_duplicates.sql
@@ -1,0 +1,1 @@
+delete from sen_oppfolging_kandidat where varsel_id in ('d611ab0d-2e7d-450f-9ad1-3334331e4094','5e494f79-9c27-4754-87a0-9cdb6b53055c','9080bcdb-4b96-45e6-8889-e61977872bca');


### PR DESCRIPTION
Fant noen flere kanditater som nettopp svarte og som har fått varsel i dag. Her må vi slette den nyeste kandidat-raden (den med varsel uten svar) slik at det vises riktig at de har svart i syfomodiaperson.