### PR TITLE
IS-2757: Log possible duplicate kandidat

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingVarselConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingVarselConsumer.kt
@@ -36,7 +36,7 @@ class SenOppfolgingVarselConsumer(private val senOppfolgingService: SenOppfolgin
                 personident = Personident(senOppfolgingVarselRecord.personident)
             )
             if (recentKandidat != null) {
-                log.warn("Found recent kandidat for person with uuid ${recentKandidat.uuid} - creating possible duplicate")
+                log.error("Found recent kandidat for person with uuid ${recentKandidat.uuid} - creating possible duplicate")
             }
 
             senOppfolgingService.createKandidat(

--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingVarselConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingVarselConsumer.kt
@@ -30,8 +30,15 @@ class SenOppfolgingVarselConsumer(private val senOppfolgingService: SenOppfolgin
     }
 
     private fun processRecord(senOppfolgingVarselRecord: KSenOppfolgingVarselDTO) {
-        val existing = senOppfolgingService.findKandidatFromVarselId(senOppfolgingVarselRecord.uuid)
-        if (existing == null) {
+        val existingKandidatForVarsel = senOppfolgingService.findKandidatFromVarselId(varselId = senOppfolgingVarselRecord.uuid)
+        if (existingKandidatForVarsel == null) {
+            val recentKandidat = senOppfolgingService.findRecentKandidatFromPersonIdent(
+                personident = Personident(senOppfolgingVarselRecord.personident)
+            )
+            if (recentKandidat != null) {
+                log.warn("Found recent kandidat for person with uuid ${recentKandidat.uuid} - creating possible duplicate")
+            }
+
             senOppfolgingService.createKandidat(
                 personident = Personident(senOppfolgingVarselRecord.personident),
                 varselAt = senOppfolgingVarselRecord.createdAt.toOffsetDateTimeUTC(),


### PR DESCRIPTION
Sjekker om det finnes en kandidat opprettet siste 3 mnder og logger dette. For å lettere kunne fange opp i loggene om vi oppretter duplikater ved innlesing.