### PR TITLE
IS-2757: Delete kandidater not varslet

### DIFF
--- a/src/main/resources/db/migration/V3_0__delete_kandidater_not_varslet.sql
+++ b/src/main/resources/db/migration/V3_0__delete_kandidater_not_varslet.sql
@@ -1,0 +1,1 @@
+delete from sen_oppfolging_kandidat where svar_at is null and varsel_id in ('73451704-b166-489f-bebf-887e1d6b0c73','fe4d94c9-2a0b-4afd-96e0-2431ef2aa155');


### PR DESCRIPTION
Sletter noen kandidater som glapp ved forrige sletting. Disse refererer til varsler som ikke har blitt sendt ut fra esyfovarsel og som ble rekjørt av esyfo.