### PR TITLE
IS-2757: Adjust log level

### DIFF
--- a/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingVarselConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/infrastructure/kafka/senoppfolging/SenOppfolgingVarselConsumer.kt
@@ -36,7 +36,7 @@ class SenOppfolgingVarselConsumer(private val senOppfolgingService: SenOppfolgin
                 personident = Personident(senOppfolgingVarselRecord.personident)
             )
             if (recentKandidat != null) {
-                log.error("Found recent kandidat for person with uuid ${recentKandidat.uuid} - creating possible duplicate")
+                log.warn("Found recent kandidat for person with uuid ${recentKandidat.uuid} - creating possible duplicate")
             }
 
             senOppfolgingService.createKandidat(


### PR DESCRIPTION
Virker som de "duplikatene" som opprettes nå er pga revarsling etter 106 dager (som enn så lenge er greit å lage kandidater for) så endrer denne til `warn` og fortsetter å følge med litt.