### PR TITLE
IS-3023: Slettet begrunnelse opprettet på feil person og tilbakestilt annen relevant informasjon

### DIFF
--- a/src/main/resources/db/migration/V3_2__delete_wrong_begrunnelse.sql
+++ b/src/main/resources/db/migration/V3_2__delete_wrong_begrunnelse.sql
@@ -1,0 +1,7 @@
+DELETE FROM sen_oppfolging_vurdering where uuid = '832ff8dd-2ce1-4981-9562-940238e93f7c';
+
+UPDATE sen_oppfolging_kandidat
+SET status = 'KANDIDAT',
+    published_at = null,
+    updated_at = now()
+WHERE uuid = '5820dd28-fcb2-46c1-a0ea-0c46151b9897';


### PR DESCRIPTION
Slettet begrunnelse som var opprettet på feil person. Noen andre bør nok dobbeltsjekke at jeg har funnet fram til korrekt id (og selvfølgelig riktig opprydning).