### PR TITLE
IS-3371: Create tables for kartleggingssporsmal

### DIFF
--- a/src/main/resources/db/migration/V3_4__create_table_kartlegging_kandidat.sql
+++ b/src/main/resources/db/migration/V3_4__create_table_kartlegging_kandidat.sql
@@ -1,0 +1,24 @@
+CREATE TABLE KARTLEGGINGSSPORSMAL_STOPPUNKT (
+    id                              SERIAL      PRIMARY KEY,
+    uuid                            CHAR(36)    NOT NULL UNIQUE,
+    created_at                      timestamptz NOT NULL,
+    personident                     CHAR(11)    NOT NULL,
+    tilfelle_bit_referanse_uuid     CHAR(36)    NOT NULL,
+    stoppunkt_at                    DATE        NOT NULL,
+    processed_at                    timestamptz
+);
+
+CREATE INDEX IX_KARTLEGGINGSSPORSMAL_STOPPUNKT_PERSONIDENT on KARTLEGGINGSSPORSMAL_STOPPUNKT (personident);
+
+CREATE TABLE KARTLEGGINGSSPORSMAL_KANDIDAT (
+    id                          SERIAL      PRIMARY KEY,
+    uuid                        CHAR(36)    NOT NULL UNIQUE,
+    created_at                  timestamptz NOT NULL,
+    personident                 CHAR(11)    NOT NULL,
+    generated_by_stoppunkt_id   INTEGER     NOT NULL REFERENCES KARTLEGGINGSSPORSMAL_STOPPUNKT(id),
+    status                      TEXT        NOT NULL,
+    varslet_at                  timestamptz
+);
+
+CREATE INDEX IX_KARTLEGGINGSSPORSMAL_KANDIDAT_PERSONIDENT on KARTLEGGINGSSPORSMAL_KANDIDAT (personident);
+CREATE INDEX IX_KARTLEGGINGSSPORSMAL_KANDIDAT_GENERATED_BY_STOPPUNKT_ID on KARTLEGGINGSSPORSMAL_KANDIDAT (generated_by_stoppunkt_id);


### PR DESCRIPTION
Hva tenker dere om dette oppsettet?

- `KARTLEGGINGSSPORSMAL_STOPPUNKT` er en tabell som lagrer ned nye stoppunkt på personer kontinuerlig ettersom det kommer inn oppfølgingstilfeller som treffer innenfor "stoppunkt-intervallet" vårt. Dette blir det samme som `FØR_KANDIDAT`/`PLANLAGT_KANDIDAT`
- Tanken er at det går en egen jobb som sjekker stoppunkt-datoene i `KARTLEGGINGSSPORSMAL_STOPPUNKT`, velger de med dagens dato, og tar avgjørelsen om de skal promoteres til kandidat eller ikke. Denne prosesseringen resulterer i en rad i `KARTLEGGINGSSPORSMAL_KANDIDAT`, med status `KANDIDAT` eller `IKKE_KANDIDAT` og en peker til hvilket stoppunkt som førte til at man vurderte "kandidaturet" `generated_by_stoppunkt_id`.
- Den samme jobben kan også sende ut varselet til `esyfovarsel`, evt blir dette en egen prosess i tillegg.
- Foreløpig har jeg lagt inn `rule_hits` og `varslet_at` også. `rule_hits` kan vi muligens vente litt med til vi har mer på plass, mens `varslet_at` trenger vi for å si om. Spørsmålet er bare om vi ønsker en egen `KARTLEGGINGSSPORSMAL_VARSEL`-tabell til dette, eller om det funker fint sånn det står. Vet ikke hva mer vi trenger av info i en sånn varsel-tabell per nå.
- Etterhvert kommer det jo inn svar på disse varselene, det jeg tenker esyfo er hovedkilden. Vi må også ha noe forhold til svarene, enten på den enkleste formen der vi registrerer at noe har kommet inn, eller at vi også lagrer ned svaret helt eller delvis. Det blir kanskje en `KARTLEGGINGSSPORSMAL_SVAR` tabell? Vi får se.