### PR TITLE
IS: Dont throw error when cannot find behandlende enhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
@@ -44,15 +44,20 @@ class KartleggingssporsmalService(
             val behandlendeEnhetDTO = behandlendeEnhetClient.getEnhet(
                 callId = UUID.randomUUID().toString(),
                 personident = oppfolgingstilfelle.personident,
-            ) ?: throw IllegalStateException("Mangler enhet for person med oppfolgingstilfelle-uuid: ${oppfolgingstilfelle.uuid}")
+            )
 
-            behandlendeEnhetDTO.oppfolgingsenhetDTO?.enhet
-                ?: behandlendeEnhetDTO.geografiskEnhet
+            if (behandlendeEnhetDTO == null) {
+                log.error("Mangler enhet for person med oppfolgingstilfelle-uuid: ${oppfolgingstilfelle.uuid}")
+                null
+            } else {
+                behandlendeEnhetDTO.oppfolgingsenhetDTO?.enhet
+                    ?: behandlendeEnhetDTO.geografiskEnhet
+            }
         }
         return oppfolgingstilfelleInsideStoppunktInterval(oppfolgingstilfelle) &&
             !oppfolgingstilfelle.isDod() &&
             !oppfolgingstilfelle.hasTilfelleWithEndMoreThanThirtyDaysAgo() &&
-            isInPilot(enhet.enhetId)
+            isInPilot(enhet?.enhetId)
     }
 
     private fun oppfolgingstilfelleInsideStoppunktInterval(oppfolgingstilfelle: Oppfolgingstilfelle): Boolean {
@@ -61,7 +66,7 @@ class KartleggingssporsmalService(
             oppfolgingstilfelle.durationInDays() <= KARTLEGGINGSSPORSMAL_STOPPUNKT_END_DAYS
     }
 
-    private fun isInPilot(enhetId: String) = enhetId in pilotkontorer
+    private fun isInPilot(enhetId: String?) = enhetId in pilotkontorer
 
     companion object {
         private val log = LoggerFactory.getLogger(KartleggingssporsmalService::class.java)

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.kartleggingssporsmal.application
 
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_ANNEN_ENHET
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_INACTIVE
 import no.nav.syfo.kartleggingssporsmal.generators.createOppfolgingstilfelle
 import no.nav.syfo.shared.util.DAYS_IN_WEEK
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -114,6 +115,18 @@ class KartleggingssporsmalServiceTest {
     fun `processOppfolgingstilfelle should return false when not in pilot office`() {
         val oppfolgingstilfelleNotPilot = createOppfolgingstilfelle(
             personident = ARBEIDSTAKER_PERSONIDENT_ANNEN_ENHET,
+            antallSykedager = stoppunktStartIntervalDays.toInt(),
+        )
+
+        val result = kartleggingssporsmalService.processOppfolgingstilfelle(oppfolgingstilfelleNotPilot)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `processOppfolgingstilfelle should return false when cannot find behandlende enhet`() {
+        val oppfolgingstilfelleNotPilot = createOppfolgingstilfelle(
+            personident = ARBEIDSTAKER_PERSONIDENT_INACTIVE,
             antallSykedager = stoppunktStartIntervalDays.toInt(),
         )
 


### PR DESCRIPTION
Jeg sendte inn en sykmelding i dev på en person som ikke har enhet. Nå står den og feiler på dette kontinuerlig. 

Tenker vi kan bare skippe disse og heller logge i prod om det skjer ofte eller ikke, jeg vil tro det ikke gjør det.