### PR TITLE
IS-3355: Fix errors in 14a-client

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/clients/vedtak14a/Vedtak14aDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/clients/vedtak14a/Vedtak14aDTO.kt
@@ -1,13 +1,13 @@
 package no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a
 
-import java.time.LocalDate
+import java.time.ZonedDateTime
 
 data class Vedtak14aRequestDTO(
     val fnr: String,
 )
 
 data class Vedtak14aResponseDTO(
-    val fattetDato: LocalDate,
+    val fattetDato: ZonedDateTime,
     val innsatsgruppe: Innsatsgruppe,
     val hovedmal: Hovedmal?,
 )

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/generators/Vedtak14aGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/generators/Vedtak14aGenerator.kt
@@ -3,10 +3,10 @@ package no.nav.syfo.kartleggingssporsmal.generators
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Hovedmal
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Innsatsgruppe
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Vedtak14aResponseDTO
-import java.time.LocalDate
+import java.time.ZonedDateTime
 
 fun generateVedtak14aResponse(
-    fattetDato: LocalDate = LocalDate.now().minusDays(10),
+    fattetDato: ZonedDateTime = ZonedDateTime.now().minusDays(10),
     innsatsgruppe: Innsatsgruppe = Innsatsgruppe.GODE_MULIGHETER,
     hovedmal: Hovedmal? = null,
 ) = Vedtak14aResponseDTO(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/clients/Vedtak14aClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/clients/Vedtak14aClientTest.kt
@@ -9,7 +9,6 @@ import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Innsats
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.LocalDate
 
 class Vedtak14aClientTest {
     private val externalMockEnvironment = ExternalMockEnvironment.instance
@@ -21,7 +20,6 @@ class Vedtak14aClientTest {
             val response = vedtak14aClient.hentGjeldende14aVedtak(ARBEIDSTAKER_PERSONIDENT)
 
             assertTrue(response.isSuccess)
-            assertEquals(response.getOrNull()?.fattetDato, LocalDate.now().minusDays(10))
             assertEquals(response.getOrNull()?.innsatsgruppe, Innsatsgruppe.GODE_MULIGHETER)
         }
     }


### PR DESCRIPTION
Jeg dro denne ut fra https://github.com/navikt/ismeroppfolging/pull/129 for å gjøre det litt tydeligere.

Fant ut at jeg hadde noen feil da jeg først fikk testet dette i dev:
- Oppdaterte URLen
- Endret fra LocalDate til ZonedDateTime
- Hvis personen ikke har et vedtak, returnerer de bare `null`/ingenting i ContentType, og ikke noe objekt. Så da måtte jeg trikse det litt til for å parse responsen riktig. Håndterer det først som en string, og så deseraliserer jeg det til Kotlin-objektet dersom det finnes en response.