### PR TITLE
IS-3422: Ensure only one kandidat per stoppunkt in database

### DIFF
--- a/src/main/resources/db/migration/V3_6__update_constraints_kartleggingssporsmal_kandidat.sql
+++ b/src/main/resources/db/migration/V3_6__update_constraints_kartleggingssporsmal_kandidat.sql
@@ -1,0 +1,15 @@
+-- First, drop the existing foreign key constraint
+ALTER TABLE KARTLEGGINGSSPORSMAL_KANDIDAT
+DROP CONSTRAINT kartleggingssporsmal_kandidat_generated_by_stoppunkt_id_fkey;
+
+-- Add the foreign key constraint back with ON DELETE CASCADE
+ALTER TABLE KARTLEGGINGSSPORSMAL_KANDIDAT
+    ADD CONSTRAINT kartleggingssporsmal_kandidat_generated_by_stoppunkt_id_fkey
+        FOREIGN KEY (generated_by_stoppunkt_id)
+            REFERENCES KARTLEGGINGSSPORSMAL_STOPPUNKT(id)
+            ON DELETE CASCADE;
+
+-- Add UNIQUE constraint to generated_by_stoppunkt_id
+ALTER TABLE KARTLEGGINGSSPORSMAL_KANDIDAT
+    ADD CONSTRAINT kartleggingssporsmal_kandidat_generated_by_stoppunkt_id_unique
+        UNIQUE (generated_by_stoppunkt_id);

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/database/KartleggingssporsmalRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/database/KartleggingssporsmalRepositoryTest.kt
@@ -179,12 +179,15 @@ class KartleggingssporsmalRepositoryTest {
             tilfelleStart = LocalDate.now().minusDays(6 * 7),
             antallSykedager = 6 * 7 + 1,
         )
-        val kartleggingssporsmalStoppunkt = KartleggingssporsmalStoppunkt.create(oppfolgingstilfelle)
-        assertNotNull(kartleggingssporsmalStoppunkt)
+        val kartleggingssporsmalStoppunkt1 = KartleggingssporsmalStoppunkt.create(oppfolgingstilfelle)
+        val kartleggingssporsmalStoppunkt2 = KartleggingssporsmalStoppunkt.create(oppfolgingstilfelle)
+        assertNotNull(kartleggingssporsmalStoppunkt1)
+        assertNotNull(kartleggingssporsmalStoppunkt2)
 
         runBlocking {
-            kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt)
-            val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
+            kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt1)
+            kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt2)
+            val createdStoppunkter = database.getKartleggingssporsmalStoppunkt()
 
             val kandidat = KartleggingssporsmalKandidat(
                 personident = ARBEIDSTAKER_PERSONIDENT,
@@ -196,11 +199,11 @@ class KartleggingssporsmalRepositoryTest {
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
-                stoppunktId = createdStoppunkt.id,
+                stoppunktId = createdStoppunkter[0].id,
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = otherKandidat,
-                stoppunktId = createdStoppunkt.id,
+                stoppunktId = createdStoppunkter[1].id,
             )
 
             val fetchedKandidat = kartleggingssporsmalRepository.getKandidat(ARBEIDSTAKER_PERSONIDENT)

--- a/src/test/kotlin/no/nav/syfo/shared/infrastructure/database/TestDatabase.kt
+++ b/src/test/kotlin/no/nav/syfo/shared/infrastructure/database/TestDatabase.kt
@@ -68,10 +68,10 @@ fun TestDatabase.dropData() {
         DELETE FROM SEN_OPPFOLGING_VURDERING
         """.trimIndent(),
         """
-        DELETE FROM KARTLEGGINGSSPORSMAL_KANDIDAT
+        DELETE FROM KARTLEGGINGSSPORSMAL_STOPPUNKT
         """.trimIndent(),
         """
-        DELETE FROM KARTLEGGINGSSPORSMAL_STOPPUNKT
+        DELETE FROM KARTLEGGINGSSPORSMAL_KANDIDAT
         """.trimIndent(),
     )
     this.connection.use { connection ->


### PR DESCRIPTION
Oppdaget at vi ikke hadde lagt inn nødvendige regler i databaseskjemaet for denne tabellen:
- `generated_by_stoppunkt_id` burde være unik for hver kandidat, ettersom et `stoppunkt` ikke kan føre til _n_ mange rader i `kandidat`. Et stoppunkt genererer 0-1 rader i kandidat-tabellen, ikke 0-n.
- Vi burde ha cascading delete -> sletter man stoppunktet, så burde også kandidaten slettes

Si ifra hvis dere er uenige i dette, eller om det er bedre måter å skrive migreringsskriptet på, har har jeg fått god hjelp av copilot. Sløyfe kommentarene, eller er de fine å ha med?