### PR TITLE
IS-3411: Add kartleggingssporsmal-svar consumer

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -100,3 +100,5 @@ spec:
       value: "dev-gcp.teamsykefravr.isoppfolgingstilfelle"
     - name: ISOPPFOLGINGSTILFELLE_URL
       value: "http://isoppfolgingstilfelle"
+    - name: IS_SVAR_TOPIC_ENABLED
+      value: "false"

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -100,3 +100,5 @@ spec:
       value: "prod-gcp.teamsykefravr.isoppfolgingstilfelle"
     - name: ISOPPFOLGINGSTILFELLE_URL
       value: "http://isoppfolgingstilfelle"
+    - name: IS_SVAR_TOPIC_ENABLED
+      value: "false"

--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.pdl.PdlClient
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Vedtak14aClient
 import no.nav.syfo.kartleggingssporsmal.infrastructure.cronjob.KandidatStoppunktCronjob
 import no.nav.syfo.kartleggingssporsmal.infrastructure.database.KartleggingssporsmalRepository
+import no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.kartleggingssporsmalsvar.launchKartleggingssporsmalSvarConsumer
 import no.nav.syfo.shared.api.apiModule
 import no.nav.syfo.senoppfolging.application.SenOppfolgingService
 import no.nav.syfo.shared.infrastructure.kafka.identhendelse.kafka.launchKafkaTaskIdenthendelse
@@ -25,7 +26,7 @@ import no.nav.syfo.shared.infrastructure.database.databaseModule
 import no.nav.syfo.senoppfolging.infrastructure.database.repository.SenOppfolgingRepository
 import no.nav.syfo.senoppfolging.infrastructure.kafka.producer.KandidatStatusProducer
 import no.nav.syfo.senoppfolging.infrastructure.kafka.producer.KandidatStatusRecordSerializer
-import no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.launchOppfolgingstilfelleConsumer
+import no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.oppfolgingstilfelle.launchOppfolgingstilfelleConsumer
 import no.nav.syfo.shared.infrastructure.kafka.kafkaAivenProducerConfig
 import no.nav.syfo.senoppfolging.infrastructure.kafka.consumer.launchSenOppfolgingSvarConsumer
 import no.nav.syfo.senoppfolging.infrastructure.kafka.consumer.launchSenOppfolgingVarselConsumer
@@ -155,6 +156,12 @@ fun main() {
                     kafkaEnvironment = environment.kafka,
                     kartleggingssporsmalService = kartleggingssporsmalService,
                 )
+                if (environment.isSvarTopicEnabled) {
+                    launchKartleggingssporsmalSvarConsumer(
+                        applicationState = applicationState,
+                        kafkaEnvironment = environment.kafka,
+                    )
+                }
             }
         }
     )

--- a/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/ApplicationEnvironment.kt
@@ -58,6 +58,7 @@ data class Environment(
                 clientId = getEnvVar("ISOPPFOLGINGSTILFELLE_CLIENT_ID"),
             ),
         ),
+    val isSvarTopicEnabled: Boolean = getEnvVar("IS_SVAR_TOPIC_ENABLED").toBoolean(),
 )
 
 fun getEnvVar(

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KafkaKartleggingssporsmalSvarDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KafkaKartleggingssporsmalSvarDTO.kt
@@ -1,0 +1,11 @@
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.kartleggingssporsmalsvar
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class KafkaKartleggingssporsmalSvarDTO(
+    val personident: String,
+    val kandidatId: UUID,
+    val svarId: UUID,
+    val createdAt: OffsetDateTime,
+)

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KartleggingssporsmalSvarConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KartleggingssporsmalSvarConsumer.kt
@@ -1,0 +1,51 @@
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.kartleggingssporsmalsvar
+
+import io.micrometer.core.instrument.Counter
+import no.nav.syfo.shared.infrastructure.kafka.KafkaConsumerService
+import no.nav.syfo.shared.infrastructure.metric.METRICS_NS
+import no.nav.syfo.shared.infrastructure.metric.METRICS_REGISTRY
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+class KartleggingssporsmalSvarConsumer() : KafkaConsumerService<KafkaKartleggingssporsmalSvarDTO> {
+
+    override val pollDurationInMillis: Long = 1000
+
+    override suspend fun pollAndProcessRecords(kafkaConsumer: KafkaConsumer<String, KafkaKartleggingssporsmalSvarDTO>) {
+        val records = kafkaConsumer.poll(Duration.ofMillis(pollDurationInMillis))
+        if (records.count() > 0) {
+            records.requireNoNulls().forEach { record ->
+                val svarRecord = record.value()
+                log.info(
+                    """
+                    Received kartleggingssporsmal svar:
+                    key: ${record.key()}
+                    svarId: ${svarRecord.svarId}
+                    """.trimIndent()
+                )
+                Metrics.COUNT_KAFKA_CONSUMER_KARTLEGGINGSSPORSMAL_SVAR_READ.increment()
+                processRecord(svarRecord)
+            }
+            kafkaConsumer.commitSync()
+        }
+    }
+
+    private suspend fun processRecord(svarRecordDTO: KafkaKartleggingssporsmalSvarDTO) {
+        // TODO
+        return
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(this::class.java)
+    }
+}
+
+private object Metrics {
+    private const val KAFKA_CONSUMER_KARTLEGGINGSSPORSMAL_SVAR_BASE = "${METRICS_NS}_kafka_consumer_kartleggingssporsmal_svar"
+
+    val COUNT_KAFKA_CONSUMER_KARTLEGGINGSSPORSMAL_SVAR_READ: Counter = Counter
+        .builder("${KAFKA_CONSUMER_KARTLEGGINGSSPORSMAL_SVAR_BASE}_read_count")
+        .description("Counts the number of reads from topic $KARTLEGGINGSSPORSMAL_SVAR_TOPIC")
+        .register(METRICS_REGISTRY)
+}

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KartleggingssporsmalSvarConsumerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KartleggingssporsmalSvarConsumerTask.kt
@@ -1,0 +1,41 @@
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.kartleggingssporsmalsvar
+
+import no.nav.syfo.ApplicationState
+import no.nav.syfo.shared.infrastructure.kafka.KafkaEnvironment
+import no.nav.syfo.shared.infrastructure.kafka.kafkaAivenConsumerConfig
+import no.nav.syfo.shared.infrastructure.kafka.launchKafkaConsumer
+import no.nav.syfo.shared.util.configuredJacksonMapper
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.OffsetResetStrategy
+import org.apache.kafka.common.serialization.Deserializer
+
+const val KARTLEGGINGSSPORSMAL_SVAR_TOPIC =
+    "team-esyfo.kartleggingssporsmal-svar"
+
+fun launchKartleggingssporsmalSvarConsumer(
+    applicationState: ApplicationState,
+    kafkaEnvironment: KafkaEnvironment,
+) {
+    val consumerProperties = kafkaAivenConsumerConfig<KafkaKartleggingssporsmalSvarDTODeserializer>(
+        kafkaEnvironment = kafkaEnvironment,
+        offsetResetStrategy = OffsetResetStrategy.EARLIEST,
+    )
+    consumerProperties.apply {
+        this[ConsumerConfig.MAX_POLL_RECORDS_CONFIG] = "100"
+    }
+
+    val kartleggingssporsmalSvarConsumer = KartleggingssporsmalSvarConsumer()
+
+    launchKafkaConsumer(
+        applicationState = applicationState,
+        topic = KARTLEGGINGSSPORSMAL_SVAR_TOPIC,
+        consumerProperties = consumerProperties,
+        kafkaConsumerService = kartleggingssporsmalSvarConsumer,
+    )
+}
+
+class KafkaKartleggingssporsmalSvarDTODeserializer : Deserializer<KafkaKartleggingssporsmalSvarDTO> {
+    private val mapper = configuredJacksonMapper()
+    override fun deserialize(topic: String, data: ByteArray): KafkaKartleggingssporsmalSvarDTO =
+        mapper.readValue(data, KafkaKartleggingssporsmalSvarDTO::class.java)
+}

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/KafkaOppfolgingstilfellePersonDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/KafkaOppfolgingstilfellePersonDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.oppfolgingstilfelle
 
 import no.nav.syfo.kartleggingssporsmal.domain.OppfolgingstilfelleDTO
 import java.time.LocalDate

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/OppfolgingstilfelleConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/OppfolgingstilfelleConsumer.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.oppfolgingstilfelle
 
 import io.micrometer.core.instrument.Counter
 import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/OppfolgingstilfelleConsumerTask.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/OppfolgingstilfelleConsumerTask.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.oppfolgingstilfelle
 
 import no.nav.syfo.ApplicationState
 import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService

--- a/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/TestEnvironment.kt
@@ -54,6 +54,7 @@ fun testEnvironment() = Environment(
         ),
     ),
     electorPath = "electorPath",
+    isSvarTopicEnabled = true,
 )
 
 fun testAppState() = ApplicationState(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/generators/OppfolgingstilfelleGenerator.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/generators/OppfolgingstilfelleGenerator.kt
@@ -6,7 +6,7 @@ import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Com
 import no.nav.syfo.kartleggingssporsmal.domain.Oppfolgingstilfelle
 import no.nav.syfo.kartleggingssporsmal.domain.OppfolgingstilfelleDTO
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.oppfolgingstilfelle.OppfolgingstilfellePersonDTO
-import no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.KafkaOppfolgingstilfellePersonDTO
+import no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.oppfolgingstilfelle.KafkaOppfolgingstilfellePersonDTO
 import no.nav.syfo.shared.domain.Personident
 import no.nav.syfo.shared.util.nowUTC
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KartleggingssporsmalSvarConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/kartleggingssporsmalsvar/KartleggingssporsmalSvarConsumerTest.kt
@@ -1,0 +1,70 @@
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.kartleggingssporsmalsvar
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
+import no.nav.syfo.shared.infrastructure.kafka.mockPollConsumerRecords
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class KartleggingssporsmalSvarConsumerTest {
+
+    private val kafkaConsumer = mockk<KafkaConsumer<String, KafkaKartleggingssporsmalSvarDTO>>()
+    val kartleggingssporsmalSvarConsumer = KartleggingssporsmalSvarConsumer()
+
+    @BeforeEach
+    fun setUp() {
+        every { kafkaConsumer.commitSync() } returns Unit
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `pollAndProcessRecords should process records and commit offsets`() {
+        val recordKey = UUID.randomUUID().toString()
+        val svarRecord = KafkaKartleggingssporsmalSvarDTO(
+            personident = ARBEIDSTAKER_PERSONIDENT.value,
+            kandidatId = UUID.randomUUID(),
+            svarId = UUID.randomUUID(),
+            createdAt = OffsetDateTime.now(),
+        )
+        kafkaConsumer.mockPollConsumerRecords(
+            records = listOf(recordKey to svarRecord),
+            topic = KARTLEGGINGSSPORSMAL_SVAR_TOPIC,
+        )
+
+        runBlocking {
+            kartleggingssporsmalSvarConsumer.pollAndProcessRecords(kafkaConsumer)
+        }
+
+        verify(exactly = 1) {
+            kafkaConsumer.commitSync()
+        }
+    }
+
+    @Test
+    fun `pollAndProcessRecords should not commit offsets if no records are processed`() {
+        kafkaConsumer.mockPollConsumerRecords(
+            records = emptyList(),
+            topic = KARTLEGGINGSSPORSMAL_SVAR_TOPIC,
+        )
+
+        runBlocking {
+            kartleggingssporsmalSvarConsumer.pollAndProcessRecords(kafkaConsumer)
+        }
+
+        verify(exactly = 0) {
+            kafkaConsumer.commitSync()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/OppfolgingstilfelleConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/consumer/oppfolgingstilfelle/OppfolgingstilfelleConsumerTest.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka
+package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka.consumer.oppfolgingstilfelle
 
 import io.mockk.clearAllMocks
 import io.mockk.every


### PR DESCRIPTION
La til en "dum" consumer som bare leser recorden og commiter sync. Foreløpig bak toggle.
Dette er DTOen vi har blitt enige med esyfo om så langt - vi trenger per nå bare å vite at en person har svart, ikke nødvendigvis svaret. Se esyfo sin branch her: https://github.com/navikt/meroppfolging-backend/commits/refs/heads/feature/bro-svar-kafka/

Videre så må vi lage _noe_ som lagrer ned at det har kommet svar på en person, og dette burde lede til en oppgave i oversikten. Har foreløpig en løs tanke om en egen `KARTLEGGINGSPORSMAL_SVAR`-tabell med `personident` og `svar_referanse_id` (+metadata), dette for å støtte flere innsendinger av svar per kandidatur i fremtiden. Alternativet er å lagre svar-info på kandidat-raden, men da mister vi den muligheten med flere svar. Hvordan dette vil se ut i domene-laget kan jo være annerledes, tenker vi kan snakke litt om det.

Avhengig av hvem som ender opp med å sende ut varselet, så kunne det jo være en ide å koble varsel-uuid til svaret også, somehow 🤔