### PR TITLE
IS-3854: Enable fritekst-skjema for enhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
@@ -10,6 +10,7 @@ import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Com
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Companion.KARTLEGGINGSSPORSMAL_MINIMUM_NUMBER_OF_DAYS_LEFT_IN_OPPFOLGINGSTILFELLE
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Companion.KARTLEGGINGSSPORSMAL_STOPPUNKT_LIMIT_DAYS_EVEN_IF_FEW_DAYS_LEFT
 import no.nav.syfo.kartleggingssporsmal.domain.Oppfolgingstilfelle
+import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.behandlendeenhet.Enhet
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.pdl.model.getAlder
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Vedtak14aResponseDTO
@@ -102,7 +103,15 @@ class KartleggingssporsmalService(
                 }
 
                 if (isKandidat) {
-                    val kandidat = KartleggingssporsmalKandidat.create(personident = stoppunkt.personident)
+                    val skjemavariant = if (enhet?.enhetId in pilotkontorerWithFritekstSkjema) {
+                        Skjemavariant.FLERVALG_FRITEKST_V1
+                    } else {
+                        Skjemavariant.FLERVALG_V1
+                    }
+                    val kandidat = KartleggingssporsmalKandidat.create(
+                        personident = stoppunkt.personident,
+                        skjemavariant = skjemavariant,
+                    )
                     val persistedKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                         kandidat = kandidat,
                         stoppunktId = stoppunktId,
@@ -296,7 +305,7 @@ class KartleggingssporsmalService(
         private const val KONTOR_NAV_OSTEROY = "1253"
         private const val KONTOR_NAV_MASFJORDEN = "1266"
         private const val KONTOR_NAV_SOLUND = "1412"
-        private val pilotkontorerMedVarsel = listOf(
+        val pilotkontorerMedVarsel = listOf(
             KONTOR_NAV_LIER,
             KONTOR_NAV_ASKER,
             KONTOR_NAV_GRORUD,
@@ -329,7 +338,7 @@ class KartleggingssporsmalService(
             KONTOR_NAV_VARNES,
             KONTOR_NAV_FOSEN,
         )
-        private val pilotkontorer = listOf(
+        val pilotkontorer = listOf(
             KONTOR_NAV_BERGEN_SENTRUM,
             KONTOR_NAV_AURLAND_LARDAL,
             KONTOR_NAV_SOGNDAL,
@@ -341,6 +350,7 @@ class KartleggingssporsmalService(
             KONTOR_NAV_MASFJORDEN,
             KONTOR_NAV_SOLUND,
         ) + pilotkontorerMedVarsel
+        val pilotkontorerWithFritekstSkjema = listOf(KONTOR_NAV_SANDEFJORD)
         private const val OPPARBEIDE_NY_SYKEPENGERETT_WEEKS = 26L
     }
 }

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidat.kt
@@ -58,13 +58,14 @@ data class KartleggingssporsmalKandidat(
     companion object {
         fun create(
             personident: Personident,
+            skjemavariant: Skjemavariant,
         ) = KartleggingssporsmalKandidat(
             uuid = UUID.randomUUID(),
             createdAt = nowUTC(),
             personident = personident,
             status = KartleggingssporsmalKandidatStatusendring.Kandidat(),
             varsletAt = null,
-            skjemavariant = Skjemavariant.FLERVALG_V1, // TODO: Må oppdateres basert på hvem som skal ha hvilke skjemaer i fremtiden
+            skjemavariant = skjemavariant,
             journalpostId = null,
         )
     }

--- a/src/test/kotlin/no/nav/syfo/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/UserConstants.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo
 
+import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService
 import no.nav.syfo.shared.domain.Personident
 import java.util.UUID
 
@@ -21,14 +22,16 @@ object UserConstants {
     val ARBEIDSTAKER_PERSONIDENT_NO_FODSELSDATO = Personident("12311111111")
     val ARBEIDSTAKER_PERSONIDENT_ONLY_FODSELSAAR = Personident("12311111199")
     val ARBEIDSTAKER_PERSONIDENT_PDL_FAILS = Personident("11111111666")
+    val ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA = Personident("55667788990")
     val EXISTING_EKSTERN_REFERANSE_UUID: UUID = UUID.fromString("e7e8e9e0-e1e2-e3e4-e5e6-e7e8e9e0e1e2")
     val FAILING_EKSTERN_REFERANSE_UUID: UUID = UUID.randomUUID()
     val PDF_DOKUMENT = byteArrayOf(0x2E, 0x28)
 
     const val VEILEDER_IDENT = "Z999999"
     const val VIRKSOMHETSNUMMER = "123456789"
-    const val VALID_PILOTKONTOR = "0220"
-    const val VALID_PILOTKONTOR_UTEN_VARSEL = "1208"
+    val VALID_PILOTKONTOR = KartleggingssporsmalService.pilotkontorerMedVarsel.first()
+    val VALID_PILOTKONTOR_UTEN_VARSEL = KartleggingssporsmalService.pilotkontorer.first()
+    val VALID_PILOTKONTOR_FRITEKST = KartleggingssporsmalService.pilotkontorerWithFritekstSkjema.first()
     const val PERSON_FORNAVN = "Fornavn"
     const val PERSON_MELLOMNAVN = "Mellomnavn"
     const val PERSON_ETTERNAVN = "Etternavnesen"

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
@@ -18,6 +18,7 @@ import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService
 import no.nav.syfo.kartleggingssporsmal.domain.KandidatStatus
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring
+import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ
 import no.nav.syfo.shared.api.generateJWT
 import no.nav.syfo.shared.api.testApiModule
@@ -69,7 +70,10 @@ class KartleggingssporsmalEndpointsTest {
         @Test
         fun `Returns status OK if valid token is supplied and kandidat exists`() = testApplication {
             val client = setupApiAndClient(kartleggingssporsmalServiceMock)
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
             coEvery { kartleggingssporsmalServiceMock.getKandidatur(ARBEIDSTAKER_PERSONIDENT) } returns listOf(kandidat)
             coEvery { kartleggingssporsmalServiceMock.getKandidatStatus(kandidat.uuid) } returns listOf(kandidat.status)
 
@@ -152,7 +156,10 @@ class KartleggingssporsmalEndpointsTest {
                     veilederident = UserConstants.VEILEDER_IDENT,
                     vurderingAlternativ = null,
                 )
-            val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(status = ferdigBehandletStatus)
             val svarAt = nowUTC().minusDays(1)
             val svarMottatt =
@@ -197,7 +204,10 @@ class KartleggingssporsmalEndpointsTest {
                     veilederident = UserConstants.VEILEDER_IDENT,
                     vurderingAlternativ = VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
                 )
-            val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(status = ferdigBehandletStatus)
             val svarAt = nowUTC().minusDays(1)
             val svarMottatt =

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
@@ -14,6 +14,7 @@ import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_HAS_14A
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_INACTIVE
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_NO_ARBEIDSGIVER
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_PILOT_UTEN_UTSENDING
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_TILFELLE_DOD
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_TILFELLE_SHORT
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_TILFELLE_SHORT_DURATION_LEFT
@@ -699,6 +700,37 @@ class KartleggingssporsmalServiceTest {
             verify(exactly = 0) { mockKandidatProducer.send(any()) }
             verify(exactly = 0) { mockEsyfoVarselProducer.send(any()) }
         }
+
+        @Test
+        fun `processStoppunkter should create kandidat with FLERVALG_FRITEKST_V1 for KONTOR_NAV_SANDEFJORD enhet`() = runTest {
+            val oppfolgingstilfelle = createOppfolgingstilfelleFromKafka(
+                personident = ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA,
+                tilfelleStart = LocalDate.now().minusDays(stoppunktStartIntervalDays),
+                antallSykedager = stoppunktStartIntervalDays.toInt() + 1,
+            )
+            val stoppunkt = KartleggingssporsmalStoppunkt.create(oppfolgingstilfelle)
+            assertNotNull(stoppunkt)
+
+            kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
+
+            val results = kartleggingssporsmalServiceWithKandidatPublishingEnabled.processStoppunkter()
+
+            assertEquals(1, results.size)
+            assertTrue(results.first().isSuccess)
+
+            val stoppunktProcessed = results.first().getOrThrow()
+            val kandidat = database.getKandidatByStoppunktUUID(stoppunktProcessed.uuid)!!
+            assertEquals(Skjemavariant.FLERVALG_FRITEKST_V1, kandidat.skjemavariant)
+
+            val producerRecordSlot = slot<ProducerRecord<String, KartleggingssporsmalKandidatStatusRecord>>()
+            verify(exactly = 1) {
+                mockKandidatProducer.send(capture(producerRecordSlot))
+            }
+
+            val kandidatStatusendringHendelse = producerRecordSlot.captured.value()
+            assertEquals(ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA.value, kandidatStatusendringHendelse.personident)
+            assertEquals(Skjemavariant.FLERVALG_FRITEKST_V1.name, kandidatStatusendringHendelse.skjemavariant)
+        }
     }
 
     @Nested
@@ -717,7 +749,10 @@ class KartleggingssporsmalServiceTest {
             kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -768,7 +803,10 @@ class KartleggingssporsmalServiceTest {
             kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -837,7 +875,10 @@ class KartleggingssporsmalServiceTest {
             kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -892,8 +933,10 @@ class KartleggingssporsmalServiceTest {
             kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
-                .copy(varsletAt = OffsetDateTime.now())
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            ).copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
                 stoppunktId = createdStoppunkt.id,
@@ -947,7 +990,10 @@ class KartleggingssporsmalServiceTest {
             kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
                 stoppunktId = createdStoppunkt.id,

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatTest.kt
@@ -13,6 +13,7 @@ class KartleggingssporsmalKandidatTest {
     fun `new kandidat has correct status and values`() {
         val newKandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+            skjemavariant = Skjemavariant.FLERVALG_V1,
         )
 
         assert(newKandidat.status is KartleggingssporsmalKandidatStatusendring.Kandidat)
@@ -26,6 +27,7 @@ class KartleggingssporsmalKandidatTest {
     fun `registrereSvarMottatt only works when status is Kandidat or SvarMottatt`() {
         val newKandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+            skjemavariant = Skjemavariant.FLERVALG_V1,
         )
 
         val svarMottattKandidat = newKandidat.registrerSvarMottatt(
@@ -52,6 +54,7 @@ class KartleggingssporsmalKandidatTest {
     fun `ferdigbehandleKandidat only works when status is SvarMottatt`() {
         val newKandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
+            skjemavariant = Skjemavariant.FLERVALG_V1,
         )
         assertThrows<IllegalArgumentException> {
             newKandidat.ferdigbehandleVurdering(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/database/KartleggingssporsmalRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/database/KartleggingssporsmalRepositoryTest.kt
@@ -149,7 +149,10 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt!!)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
                 stoppunktId = createdStoppunkt.id,
@@ -186,8 +189,10 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt!!)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
-                .copy(skjemavariant = Skjemavariant.FLERVALG_FRITEKST_V1)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_FRITEKST_V1,
+            )
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
                 stoppunktId = createdStoppunkt.id,
@@ -227,8 +232,14 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt2!!)
             val createdStoppunkter = database.getKartleggingssporsmalStoppunkt()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
-            val otherKandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
+            val otherKandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(createdAt = OffsetDateTime.now().minusHours(1))
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -260,7 +271,10 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt!!)
             val createdStoppunkter = database.getKartleggingssporsmalStoppunkt()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
                 stoppunktId = createdStoppunkter[0].id,
@@ -284,7 +298,10 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt!!)
             val createdStoppunkter = database.getKartleggingssporsmalStoppunkt()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
                 stoppunktId = createdStoppunkter[0].id,
@@ -314,8 +331,14 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt2!!)
             val createdStoppunkter = database.getKartleggingssporsmalStoppunkt()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
-            val otherKandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
+            val otherKandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(createdAt = OffsetDateTime.now().minusHours(1))
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -348,7 +371,10 @@ class KartleggingssporsmalRepositoryTest {
             kartleggingssporsmalRepository.createStoppunkt(kartleggingssporsmalStoppunkt!!)
             val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -365,7 +391,10 @@ class KartleggingssporsmalRepositoryTest {
 
     @Test
     fun `updateSvarForKandidat should throw an exception when the kandidat does not exist`() {
-        val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+        val kandidat = KartleggingssporsmalKandidat.create(
+            personident = ARBEIDSTAKER_PERSONIDENT,
+            skjemavariant = Skjemavariant.FLERVALG_V1,
+        )
         val kandidatSvarMottatt = kandidat.registrerSvarMottatt(OffsetDateTime.now())
         runBlocking {
             assertThrows<NoSuchElementException> {

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/journalforing/JournalforingServiceTest.kt
@@ -16,6 +16,7 @@ import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt
+import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
 import no.nav.syfo.kartleggingssporsmal.generators.createOppfolgingstilfelleFromKafka
 import no.nav.syfo.kartleggingssporsmal.generators.generateJournalpostRequest
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.dokarkiv.DokarkivClient
@@ -143,7 +144,10 @@ class JournalforingServiceTest {
 
     @Test
     fun `feiler når kall til pdl feiler`() {
-        val kandidat = KartleggingssporsmalKandidat.create(personident = UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS)
+        val kandidat = KartleggingssporsmalKandidat.create(
+            personident = UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS,
+            skjemavariant = Skjemavariant.FLERVALG_V1,
+        )
 
         val result = runBlocking {
             journalforingService.journalfor(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/EsyfovarselProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/EsyfovarselProducerTest.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.kartleggingssporsmal.infrastructure.kafka
 import io.mockk.*
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
+import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import org.apache.kafka.clients.producer.RecordMetadata
@@ -31,7 +32,10 @@ class EsyfovarselProducerTest {
 
         @Test
         fun `sendKartleggingssporsmal should send varsel`() {
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
 
             val result = esyfovarselProducer.sendKartleggingssporsmal(kandidat)
 
@@ -53,7 +57,10 @@ class EsyfovarselProducerTest {
                 kafkaProducer.send(any())
             } throws RuntimeException("Kafka error")
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
 
             val result = esyfovarselProducer.sendKartleggingssporsmal(kandidat)
 
@@ -72,7 +79,10 @@ class EsyfovarselProducerTest {
 
         @Test
         fun `ferdigstillKartleggingssporsmalVarsel should send varsel with ferdigstill flag true`() {
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
 
             val result = esyfovarselProducer.ferdigstillKartleggingssporsmalVarsel(kandidat)
 
@@ -94,7 +104,10 @@ class EsyfovarselProducerTest {
                 kafkaProducer.send(any())
             } throws RuntimeException("Kafka error")
 
-            val kandidat = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+            val kandidat = KartleggingssporsmalKandidat.create(
+                personident = ARBEIDSTAKER_PERSONIDENT,
+                skjemavariant = Skjemavariant.FLERVALG_V1,
+            )
             val result = esyfovarselProducer.ferdigstillKartleggingssporsmalVarsel(kandidat)
 
             assertTrue(result.isFailure)

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/mock/BehandlendeenhetMock.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/mock/BehandlendeenhetMock.kt
@@ -6,6 +6,8 @@ import io.ktor.http.HttpStatusCode
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_ANNEN_ENHET
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_INACTIVE
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_PILOT_UTEN_UTSENDING
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA
+import no.nav.syfo.UserConstants.VALID_PILOTKONTOR_FRITEKST
 import no.nav.syfo.UserConstants.VALID_PILOTKONTOR_UTEN_VARSEL
 import no.nav.syfo.kartleggingssporsmal.generators.getBehandlendeEnhetDTO
 import no.nav.syfo.shared.infrastructure.mock.respond
@@ -22,6 +24,9 @@ fun MockRequestHandleScope.behandlendeenhetResponse(request: HttpRequestData): H
         )
         ARBEIDSTAKER_PERSONIDENT_PILOT_UTEN_UTSENDING.value -> respond(
             getBehandlendeEnhetDTO(geografiskEnhetId = VALID_PILOTKONTOR_UTEN_VARSEL)
+        )
+        ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA.value -> respond(
+            getBehandlendeEnhetDTO(geografiskEnhetId = VALID_PILOTKONTOR_FRITEKST)
         )
         else -> respond(getBehandlendeEnhetDTO())
     }


### PR DESCRIPTION
## Beskrivelse

Oppdaterer `KartleggingssporsmalKandidat.create()` til å ta imot `skjemavariant` som obligatorisk parameter, slik at kandidater kan opprettes med riktig spørsmålsskjema basert på hvilken NAV-enhet de tilhører.

Kandidater fra **KONTOR_NAV_SANDEFJORD** (enhet `0710`) får `FLERVALG_FRITEKST_V1`, mens alle andre pilotkontorer fortsatt får `FLERVALG_V1`.

## Endringer

- **Domene**: `KartleggingssporsmalKandidat.create()` krever nå `skjemavariant` som parameter
- **Tester**: Oppdaterer alle eksisterende testkall til å bruke `Skjemavariant.FLERVALG_V1` som standard
- **Ny testinfrastruktur**: Legger til `ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA` og `KONTOR_NAV_SANDEFJORD` i `UserConstants`, samt ny branch i `BehandlendeenhetMock`
- **Nye tester**: Verifiserer at kandidater fra Sandefjord-enheten får `FLERVALG_FRITEKST_V1`

- [ ] Vente til merge i frontend før denne går ut
- [ ] Teste i dev