### PR TITLE
Reapply "IS-3867: Add vurderingAlternativ to query parameter in API"

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpoints.kt
@@ -1,17 +1,21 @@
 package no.nav.syfo.kartleggingssporsmal.api.endpoints
 
 import io.ktor.http.*
+import io.ktor.server.plugins.*
+import io.ktor.server.request.*
+import io.ktor.server.request.ContentTransformationException
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
-import no.nav.syfo.kartleggingssporsmal.api.endpoints.dto.KandidatStatusDTO
-import no.nav.syfo.kartleggingssporsmal.api.endpoints.dto.toKandidatStatusDTO
+import no.nav.syfo.kartleggingssporsmal.api.model.KandidatStatusDTO
+import no.nav.syfo.kartleggingssporsmal.api.model.KartleggingssporsmalRequestDTO
+import no.nav.syfo.kartleggingssporsmal.api.model.toKandidatStatusDTO
 import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService
 import no.nav.syfo.shared.infrastructure.clients.veiledertilgang.VeilederTilgangskontrollClient
 import no.nav.syfo.shared.infrastructure.clients.veiledertilgang.validateVeilederAccess
 import no.nav.syfo.shared.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.shared.util.getNAVIdent
 import no.nav.syfo.shared.util.getPersonident
-import java.util.UUID
+import java.util.*
 
 private const val API_ACTION = "access received kartleggingssporsmål for person"
 
@@ -21,8 +25,9 @@ fun Route.registerKartleggingssporsmalEndpoints(
 ) {
     route("/api/internad/v1/kartleggingssporsmal") {
         get("/kandidater") {
-            val personident = call.getPersonident()
-                ?: throw IllegalArgumentException("Failed to $API_ACTION: No $NAV_PERSONIDENT_HEADER supplied in request header")
+            val personident =
+                call.getPersonident()
+                    ?: throw IllegalArgumentException("Failed to $API_ACTION: No $NAV_PERSONIDENT_HEADER supplied in request header")
             validateVeilederAccess(
                 action = API_ACTION,
                 personident = personident,
@@ -30,13 +35,14 @@ fun Route.registerKartleggingssporsmalEndpoints(
             ) {
                 val kandidater = kartleggingssporsmalService.getKandidatur(personident)
                 if (kandidater.isNotEmpty()) {
-                    val responseList = kandidater.map {
-                        val kandidatStatusListe = kartleggingssporsmalService.getKandidatStatus(it.uuid)
-                        it.toKandidatStatusDTO(kandidatStatusListe)
-                    }
+                    val responseList =
+                        kandidater.map {
+                            val kandidatStatusListe = kartleggingssporsmalService.getKandidatStatus(it.uuid)
+                            it.toKandidatStatusDTO(kandidatStatusListe)
+                        }
                     call.respond<List<KandidatStatusDTO>>(
                         status = HttpStatusCode.OK,
-                        message = responseList
+                        message = responseList,
                     )
                 } else {
                     call.respond(HttpStatusCode.NotFound)
@@ -44,27 +50,42 @@ fun Route.registerKartleggingssporsmalEndpoints(
             }
         }
         put("/kandidater/{uuid}") {
-            val veilederident = call.getNAVIdent()
-                ?: throw IllegalArgumentException("Failed to $API_ACTION: No NAV_IDENT supplied in request header")
-            val kandidatUUID = call.parameters["uuid"]?.let { UUID.fromString(it) }
-                ?: throw IllegalArgumentException("Failed to $API_ACTION: No kandidat UUID supplied in request path")
-            val kandidat = kartleggingssporsmalService.getKandidat(kandidatUUID)
-                ?: throw IllegalArgumentException("Failed to $API_ACTION: No kandidat found for UUID $kandidatUUID")
+            val veilederident =
+                call.getNAVIdent()
+                    ?: throw IllegalArgumentException("Failed to $API_ACTION: No NAV_IDENT supplied in request header")
+            val kandidatUUID =
+                call.parameters["uuid"]?.let { UUID.fromString(it) }
+                    ?: throw IllegalArgumentException("Failed to $API_ACTION: No kandidat UUID supplied in request path")
+            val kandidat =
+                kartleggingssporsmalService.getKandidat(kandidatUUID)
+                    ?: throw IllegalArgumentException("Failed to $API_ACTION: No kandidat found for UUID $kandidatUUID")
+
+            // TODO: Remove when frontend sends valid JSON
+            val requestDTO =
+                try {
+                    call.receiveNullable<KartleggingssporsmalRequestDTO>() ?: KartleggingssporsmalRequestDTO()
+                } catch (e: ContentTransformationException) {
+                    KartleggingssporsmalRequestDTO()
+                } catch (e: BadRequestException) {
+                    KartleggingssporsmalRequestDTO()
+                }
 
             validateVeilederAccess(
                 action = API_ACTION,
                 personident = kandidat.personident,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
             ) {
-                val kandidat = kartleggingssporsmalService.registrerFerdigbehandlet(
-                    uuid = kandidatUUID,
-                    veilederident = veilederident,
-                )
+                val kandidat =
+                    kartleggingssporsmalService.registrerFerdigbehandlet(
+                        uuid = kandidatUUID,
+                        veilederident = veilederident,
+                        vurderingAlternativ = requestDTO.vurderingAlternativ,
+                    )
                 val kandidatStatusListe = kartleggingssporsmalService.getKandidatStatus(kandidat.uuid)
 
                 call.respond<KandidatStatusDTO>(
                     status = HttpStatusCode.OK,
-                    message = kandidat.toKandidatStatusDTO(kandidatStatusListe)
+                    message = kandidat.toKandidatStatusDTO(kandidatStatusListe),
                 )
             }
         }

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/model/KandidatStatusDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/model/KandidatStatusDTO.kt
@@ -1,4 +1,4 @@
-package no.nav.syfo.kartleggingssporsmal.api.endpoints.dto
+package no.nav.syfo.kartleggingssporsmal.api.model
 
 import no.nav.syfo.kartleggingssporsmal.domain.KandidatStatus
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
@@ -21,6 +21,7 @@ data class KandidatStatusDTO(
 data class VurderingDTO(
     val vurdertAt: OffsetDateTime,
     val vurdertBy: String,
+    val vurderingAlternativ: KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ?,
 )
 
 fun KartleggingssporsmalKandidat.toKandidatStatusDTO(
@@ -38,6 +39,7 @@ fun KartleggingssporsmalKandidat.toKandidatStatusDTO(
             VurderingDTO(
                 vurdertAt = it.createdAt,
                 vurdertBy = (it as KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet).veilederident,
+                vurderingAlternativ = it.vurderingAlternativ,
             )
         },
     createdAt = this.createdAt

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/model/KartleggingssporsmalRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/model/KartleggingssporsmalRequestDTO.kt
@@ -1,0 +1,7 @@
+package no.nav.syfo.kartleggingssporsmal.api.model
+
+import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ
+
+data class KartleggingssporsmalRequestDTO(
+    val vurderingAlternativ: VurderingAlternativ? = null,
+)

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
@@ -145,7 +145,7 @@ class KartleggingssporsmalService(
     suspend fun registrerFerdigbehandlet(
         uuid: UUID,
         veilederident: String,
-        vurderingAlternativ: VurderingAlternativ? = null, // TODO: Hent fra APIet i stedet
+        vurderingAlternativ: VurderingAlternativ?, // TODO: Make required when frontend makes use of it
     ): KartleggingssporsmalKandidat {
         val existingKandidat =
             kartleggingssporsmalRepository.getKandidat(uuid) ?: throw IllegalArgumentException("Kandidat med uuid $uuid finnes ikke")

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
@@ -13,11 +13,12 @@ import io.mockk.mockk
 import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
-import no.nav.syfo.kartleggingssporsmal.api.endpoints.dto.KandidatStatusDTO
+import no.nav.syfo.kartleggingssporsmal.api.model.KandidatStatusDTO
 import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService
 import no.nav.syfo.kartleggingssporsmal.domain.KandidatStatus
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring
+import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ
 import no.nav.syfo.shared.api.generateJWT
 import no.nav.syfo.shared.api.testApiModule
 import no.nav.syfo.shared.util.NAV_PERSONIDENT_HEADER
@@ -145,7 +146,7 @@ class KartleggingssporsmalEndpointsTest {
         private val kartleggingssporsmalFerdigbehandleUrl = "/api/internad/v1/kartleggingssporsmal/kandidater/"
 
         @Test
-        fun `Returns status OK if valid token is supplied and kandidat exists`() = testApplication {
+        fun `Returns status OK if valid token is supplied, kandidat exists, and no vurdering`() = testApplication {
             val ferdigBehandletStatus =
                 KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet(
                     veilederident = UserConstants.VEILEDER_IDENT,
@@ -164,8 +165,9 @@ class KartleggingssporsmalEndpointsTest {
             val client = setupApiAndClient(kartleggingssporsmalServiceMock)
             coEvery {
                 kartleggingssporsmalServiceMock.registrerFerdigbehandlet(
-                    kandidatFerdigbehandlet.uuid,
-                    any()
+                    uuid = kandidatFerdigbehandlet.uuid,
+                    veilederident = any(),
+                    vurderingAlternativ = any(),
                 )
             } returns kandidatFerdigbehandlet
             coEvery { kartleggingssporsmalServiceMock.getKandidat(kandidatFerdigbehandlet.uuid) } returns kandidatFerdigbehandlet
@@ -185,12 +187,66 @@ class KartleggingssporsmalEndpointsTest {
             assertEquals(KandidatStatus.FERDIGBEHANDLET, responseDTO.status)
             assertEquals(UserConstants.VEILEDER_IDENT, responseDTO.vurdering?.vurdertBy)
             assertEquals(ferdigBehandletStatus.createdAt, responseDTO.vurdering?.vurdertAt)
+            assertEquals(ferdigBehandletStatus.vurderingAlternativ, responseDTO.vurdering?.vurderingAlternativ)
+        }
+
+        @Test
+        fun `Returns status OK if valid token is supplied, kandidat exists, and vurdering`() = testApplication {
+            val ferdigBehandletStatus =
+                KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet(
+                    veilederident = UserConstants.VEILEDER_IDENT,
+                    vurderingAlternativ = VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
+                )
+            val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(personident = ARBEIDSTAKER_PERSONIDENT)
+                .copy(status = ferdigBehandletStatus)
+            val svarAt = nowUTC().minusDays(1)
+            val svarMottatt =
+                KartleggingssporsmalKandidatStatusendring.SvarMottatt(svarAt = svarAt)
+            val kandidatStatusendringer = listOf(
+                ferdigBehandletStatus,
+                svarMottatt,
+                KartleggingssporsmalKandidatStatusendring.Kandidat()
+            )
+            val client = setupApiAndClient(kartleggingssporsmalServiceMock)
+            coEvery {
+                kartleggingssporsmalServiceMock.registrerFerdigbehandlet(
+                    uuid = kandidatFerdigbehandlet.uuid,
+                    veilederident = any(),
+                    vurderingAlternativ = any(),
+                )
+            } returns kandidatFerdigbehandlet
+            coEvery { kartleggingssporsmalServiceMock.getKandidat(kandidatFerdigbehandlet.uuid) } returns kandidatFerdigbehandlet
+            coEvery { kartleggingssporsmalServiceMock.getKandidatStatus(kandidatFerdigbehandlet.uuid) } returns kandidatStatusendringer
+
+            val response = client.put("$kartleggingssporsmalFerdigbehandleUrl${kandidatFerdigbehandlet.uuid}") {
+                bearerAuth(validToken)
+                header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
+                contentType(ContentType.Application.Json)
+                setBody("""{"vurderingAlternativ":"IKKE_RISIKO_FOR_LANGTIDSFRAVAR"}""")
+            }
+
+            assertEquals(HttpStatusCode.OK, response.status)
+
+            val responseDTO = response.body<KandidatStatusDTO>()
+            assertEquals(kandidatFerdigbehandlet.uuid, responseDTO.kandidatUuid)
+            assertEquals(kandidatFerdigbehandlet.personident, responseDTO.personident)
+            assertEquals(svarAt, responseDTO.svarAt)
+            assertEquals(KandidatStatus.FERDIGBEHANDLET, responseDTO.status)
+            assertEquals(UserConstants.VEILEDER_IDENT, responseDTO.vurdering?.vurdertBy)
+            assertEquals(ferdigBehandletStatus.createdAt, responseDTO.vurdering?.vurdertAt)
+            assertEquals(ferdigBehandletStatus.vurderingAlternativ, responseDTO.vurdering?.vurderingAlternativ)
         }
 
         @Test
         fun `Returns status NotFound if valid token is supplied, but kandidat doesn't exist`() = testApplication {
             val client = setupApiAndClient(kartleggingssporsmalServiceMock)
-            coEvery { kartleggingssporsmalServiceMock.registrerFerdigbehandlet(any(), any()) } throws IllegalArgumentException()
+            coEvery {
+                kartleggingssporsmalServiceMock.registrerFerdigbehandlet(
+                    uuid = any(),
+                    veilederident = any(),
+                    vurderingAlternativ = any()
+                )
+            } throws IllegalArgumentException()
 
             val response = client.put("$kartleggingssporsmalFerdigbehandleUrl${UUID.randomUUID()}") {
                 bearerAuth(validToken)

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
@@ -853,6 +853,7 @@ class KartleggingssporsmalServiceTest {
             val returnedKandidat = kartleggingssporsmalService.registrerFerdigbehandlet(
                 uuid = createdKandidat.uuid,
                 veilederident = ferdigbehandletBy,
+                vurderingAlternativ = null
             )
             assertEquals(createdKandidat.uuid, returnedKandidat.uuid)
             assertEquals(ARBEIDSTAKER_PERSONIDENT, returnedKandidat.personident)
@@ -955,6 +956,7 @@ class KartleggingssporsmalServiceTest {
                 kartleggingssporsmalService.registrerFerdigbehandlet(
                     uuid = kandidat.uuid,
                     veilederident = UserConstants.VEILEDER_IDENT,
+                    vurderingAlternativ = VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR
                 )
             }
         }
@@ -965,6 +967,7 @@ class KartleggingssporsmalServiceTest {
                 kartleggingssporsmalService.registrerFerdigbehandlet(
                     uuid = UUID.randomUUID(),
                     veilederident = UserConstants.VEILEDER_IDENT,
+                    vurderingAlternativ = VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR
                 )
             }
         }


### PR DESCRIPTION
Vi fikk inn prodfeil på requests mot `PUT /kandidater/{uuid}`. Årsaken var at parsingen av `requestDTO`, ment som en helgardering, ikke fungerte i prod siden KTOR (`call.receiveNullable<KartleggingssporsmalRequestDTO>()`) kastet en `BadRequestException` fremfor en `ContentTransformationException` som dokumentasjonen tilsier. Det som er ekstra snodig er at vi allerede har tester på dette, og de fungerer fint i dev. Jeg har også testet dette med debug mode. Dermed sjekker jeg i dev for å se om problemet har løst seg med å legge på en ekstra

```
catch (e: BadRequestException) {
    KartleggingssporsmalRequestDTO()
}
```