### PR TITLE
IS-4068: Remove nullable VurderingAlternativ on PUT request

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpoints.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpoints.kt
@@ -1,9 +1,7 @@
 package no.nav.syfo.kartleggingssporsmal.api.endpoints
 
 import io.ktor.http.*
-import io.ktor.server.plugins.*
 import io.ktor.server.request.*
-import io.ktor.server.request.ContentTransformationException
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.kartleggingssporsmal.api.model.KandidatStatusDTO
@@ -50,9 +48,7 @@ fun Route.registerKartleggingssporsmalEndpoints(
             }
         }
         put("/kandidater/{uuid}") {
-            val veilederident =
-                call.getNAVIdent()
-                    ?: throw IllegalArgumentException("Failed to $API_ACTION: No NAV_IDENT supplied in request header")
+            val veilederident = call.getNAVIdent()
             val kandidatUUID =
                 call.parameters["uuid"]?.let { UUID.fromString(it) }
                     ?: throw IllegalArgumentException("Failed to $API_ACTION: No kandidat UUID supplied in request path")
@@ -60,22 +56,14 @@ fun Route.registerKartleggingssporsmalEndpoints(
                 kartleggingssporsmalService.getKandidat(kandidatUUID)
                     ?: throw IllegalArgumentException("Failed to $API_ACTION: No kandidat found for UUID $kandidatUUID")
 
-            // TODO: Remove when frontend sends valid JSON
-            val requestDTO =
-                try {
-                    call.receiveNullable<KartleggingssporsmalRequestDTO>() ?: KartleggingssporsmalRequestDTO()
-                } catch (e: ContentTransformationException) {
-                    KartleggingssporsmalRequestDTO()
-                } catch (e: BadRequestException) {
-                    KartleggingssporsmalRequestDTO()
-                }
-
             validateVeilederAccess(
                 action = API_ACTION,
                 personident = kandidat.personident,
                 veilederTilgangskontrollClient = veilederTilgangskontrollClient,
                 requiresWriteAccess = true,
             ) {
+                val requestDTO = call.receive<KartleggingssporsmalRequestDTO>()
+
                 val kandidat =
                     kartleggingssporsmalService.registrerFerdigbehandlet(
                         uuid = kandidatUUID,

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/model/KartleggingssporsmalRequestDTO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/api/model/KartleggingssporsmalRequestDTO.kt
@@ -3,5 +3,5 @@ package no.nav.syfo.kartleggingssporsmal.api.model
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ
 
 data class KartleggingssporsmalRequestDTO(
-    val vurderingAlternativ: VurderingAlternativ? = null,
+    val vurderingAlternativ: VurderingAlternativ,
 )

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
@@ -2,15 +2,11 @@ package no.nav.syfo.kartleggingssporsmal.application
 
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
-import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
-import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring
+import no.nav.syfo.kartleggingssporsmal.domain.*
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ
-import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt
-import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Companion.KARTLEGGINGSSPORSMAL_STOPPUNKT_START_DAYS
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Companion.KARTLEGGINGSSPORSMAL_MINIMUM_NUMBER_OF_DAYS_LEFT_IN_OPPFOLGINGSTILFELLE
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Companion.KARTLEGGINGSSPORSMAL_STOPPUNKT_LIMIT_DAYS_EVEN_IF_FEW_DAYS_LEFT
-import no.nav.syfo.kartleggingssporsmal.domain.Oppfolgingstilfelle
-import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
+import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalStoppunkt.Companion.KARTLEGGINGSSPORSMAL_STOPPUNKT_START_DAYS
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.behandlendeenhet.Enhet
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.pdl.model.getAlder
 import no.nav.syfo.kartleggingssporsmal.infrastructure.clients.vedtak14a.Vedtak14aResponseDTO
@@ -20,7 +16,7 @@ import no.nav.syfo.shared.util.toLocalDateOslo
 import org.slf4j.LoggerFactory
 import java.time.LocalDate
 import java.time.OffsetDateTime
-import java.util.UUID
+import java.util.*
 
 class KartleggingssporsmalService(
     private val behandlendeEnhetClient: IBehandlendeEnhetClient,
@@ -183,7 +179,7 @@ class KartleggingssporsmalService(
     suspend fun registrerFerdigbehandlet(
         uuid: UUID,
         veilederident: String,
-        vurderingAlternativ: VurderingAlternativ?, // TODO: Make required when frontend makes use of it
+        vurderingAlternativ: VurderingAlternativ,
     ): KartleggingssporsmalKandidat {
         val existingKandidat =
             kartleggingssporsmalRepository.getKandidat(uuid) ?: throw IllegalArgumentException("Kandidat med uuid $uuid finnes ikke")

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidat.kt
@@ -42,7 +42,7 @@ data class KartleggingssporsmalKandidat(
 
     fun ferdigbehandleVurdering(
         veilederident: String,
-        vurderingAlternativ: VurderingAlternativ?,
+        vurderingAlternativ: VurderingAlternativ,
     ): KartleggingssporsmalKandidat {
         if (this.status !is KartleggingssporsmalKandidatStatusendring.SvarMottatt) {
             throw IllegalArgumentException("Ferdigbehandling feilet: Kandidaten må ha status ${KartleggingssporsmalKandidatStatusendring.SvarMottatt::class.simpleName} for å ferdigbehandles, men var ${status.kandidatStatus} ")

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatStatusendring.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatStatusendring.kt
@@ -77,7 +77,7 @@ sealed class KartleggingssporsmalKandidatStatusendring(
     ) {
         override val kandidatStatus: KandidatStatus = KandidatStatus.FERDIGBEHANDLET
 
-        constructor(veilederident: String, vurderingAlternativ: VurderingAlternativ?) : this(
+        constructor(veilederident: String, vurderingAlternativ: VurderingAlternativ) : this(
             uuid = UUID.randomUUID(),
             createdAt = nowUTC(),
             publishedAt = null,

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
@@ -14,15 +14,16 @@ import no.nav.syfo.ExternalMockEnvironment
 import no.nav.syfo.UserConstants
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.kartleggingssporsmal.api.model.KandidatStatusDTO
+import no.nav.syfo.kartleggingssporsmal.api.model.KartleggingssporsmalRequestDTO
 import no.nav.syfo.kartleggingssporsmal.application.KartleggingssporsmalService
 import no.nav.syfo.kartleggingssporsmal.domain.KandidatStatus
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidat
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring
-import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
 import no.nav.syfo.kartleggingssporsmal.domain.KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ
+import no.nav.syfo.kartleggingssporsmal.domain.Skjemavariant
 import no.nav.syfo.shared.api.testApiModule
-import no.nav.syfo.shared.api.tokenForVeilederWithNoWriteTilgang
 import no.nav.syfo.shared.api.tokenForVeilederWithFullTilgang
+import no.nav.syfo.shared.api.tokenForVeilederWithNoWriteTilgang
 import no.nav.syfo.shared.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.shared.util.configure
 import no.nav.syfo.shared.util.nowUTC
@@ -145,53 +146,9 @@ class KartleggingssporsmalEndpointsTest {
     inner class PostKartleggingssporsmal {
         private val kartleggingssporsmalFerdigbehandleUrl = "/api/internad/v1/kartleggingssporsmal/kandidater/"
 
-        @Test
-        fun `Returns status OK if valid token is supplied, kandidat exists, and no vurdering`() = testApplication {
-            val ferdigBehandletStatus =
-                KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet(
-                    veilederident = UserConstants.VEILEDER_IDENT,
-                    vurderingAlternativ = null,
-                )
-            val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(
-                personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
-            )
-                .copy(status = ferdigBehandletStatus)
-            val svarAt = nowUTC().minusDays(1)
-            val svarMottatt =
-                KartleggingssporsmalKandidatStatusendring.SvarMottatt(svarAt = svarAt)
-            val kandidatStatusendringer = listOf(
-                ferdigBehandletStatus,
-                svarMottatt,
-                KartleggingssporsmalKandidatStatusendring.Kandidat()
-            )
-            val client = setupApiAndClient(kartleggingssporsmalServiceMock)
-            coEvery {
-                kartleggingssporsmalServiceMock.registrerFerdigbehandlet(
-                    uuid = kandidatFerdigbehandlet.uuid,
-                    veilederident = any(),
-                    vurderingAlternativ = any(),
-                )
-            } returns kandidatFerdigbehandlet
-            coEvery { kartleggingssporsmalServiceMock.getKandidat(kandidatFerdigbehandlet.uuid) } returns kandidatFerdigbehandlet
-            coEvery { kartleggingssporsmalServiceMock.getKandidatStatus(kandidatFerdigbehandlet.uuid) } returns kandidatStatusendringer
-
-            val response = client.put("$kartleggingssporsmalFerdigbehandleUrl${kandidatFerdigbehandlet.uuid}") {
-                bearerAuth(validToken)
-                header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
-            }
-
-            assertEquals(HttpStatusCode.OK, response.status)
-
-            val responseDTO = response.body<KandidatStatusDTO>()
-            assertEquals(kandidatFerdigbehandlet.uuid, responseDTO.kandidatUuid)
-            assertEquals(kandidatFerdigbehandlet.personident, responseDTO.personident)
-            assertEquals(svarAt, responseDTO.svarAt)
-            assertEquals(KandidatStatus.FERDIGBEHANDLET, responseDTO.status)
-            assertEquals(UserConstants.VEILEDER_IDENT, responseDTO.vurdering?.vurdertBy)
-            assertEquals(ferdigBehandletStatus.createdAt, responseDTO.vurdering?.vurdertAt)
-            assertEquals(ferdigBehandletStatus.vurderingAlternativ, responseDTO.vurdering?.vurderingAlternativ)
-        }
+        private val requestDto = KartleggingssporsmalRequestDTO(
+            vurderingAlternativ = VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
+        )
 
         @Test
         fun `Returns status OK if valid token is supplied, kandidat exists, and vurdering`() = testApplication {
@@ -274,6 +231,8 @@ class KartleggingssporsmalEndpointsTest {
             val response = client.put("$kartleggingssporsmalFerdigbehandleUrl${UUID.randomUUID()}") {
                 bearerAuth(validToken)
                 header(NAV_PERSONIDENT_HEADER, ARBEIDSTAKER_PERSONIDENT.value)
+                contentType(ContentType.Application.Json)
+                setBody(requestDto)
             }
 
             assertEquals(HttpStatusCode.BadRequest, response.status)

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
@@ -10,11 +10,11 @@ import no.nav.syfo.UserConstants
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_ANNEN_ENHET
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_ERROR
+import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_HAS_14A
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_INACTIVE
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_NO_ARBEIDSGIVER
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_PILOT_UTEN_UTSENDING
-import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_FRITEKST_SKJEMA
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_TILFELLE_DOD
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_TILFELLE_SHORT
 import no.nav.syfo.UserConstants.ARBEIDSTAKER_PERSONIDENT_TILFELLE_SHORT_DURATION_LEFT
@@ -865,64 +865,6 @@ class KartleggingssporsmalServiceTest {
     @Nested
     @DisplayName("Test registrering of ferdig behandlet")
     inner class RegistrerFerdigBehandlet {
-
-        @Test
-        fun `registrer ferdig behandlet should store status and veilederident`() = runTest {
-            val oppfolgingstilfelle = createOppfolgingstilfelleFromKafka(
-                tilfelleStart = LocalDate.now().minusDays(stoppunktStartIntervalDays),
-                antallSykedager = stoppunktStartIntervalDays.toInt() + 1,
-            )
-            val stoppunkt = KartleggingssporsmalStoppunkt.create(oppfolgingstilfelle)!!
-            kartleggingssporsmalRepository.createStoppunkt(stoppunkt)
-            val createdStoppunkt = database.getKartleggingssporsmalStoppunkt().first()
-
-            val kandidat = KartleggingssporsmalKandidat.create(
-                personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
-            )
-                .copy(varsletAt = OffsetDateTime.now())
-            val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
-                kandidat = kandidat,
-                stoppunktId = createdStoppunkt.id,
-            )
-
-            kartleggingssporsmalService.registrerSvar(
-                kandidatUuid = createdKandidat.uuid,
-                svarAt = OffsetDateTime.now(),
-                svarId = UUID.randomUUID(),
-            )
-            val ferdigbehandletBy = UserConstants.VEILEDER_IDENT
-            val returnedKandidat = kartleggingssporsmalService.registrerFerdigbehandlet(
-                uuid = createdKandidat.uuid,
-                veilederident = ferdigbehandletBy,
-                vurderingAlternativ = null
-            )
-            assertEquals(createdKandidat.uuid, returnedKandidat.uuid)
-            assertEquals(ARBEIDSTAKER_PERSONIDENT, returnedKandidat.personident)
-            assertTrue(returnedKandidat.status is KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet)
-            assertEquals(
-                ferdigbehandletBy,
-                (returnedKandidat.status as KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet).veilederident
-            )
-
-            val fetchedKandidat = kartleggingssporsmalRepository.getKandidat(createdKandidat.uuid)
-            assertTrue(fetchedKandidat?.status is KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet)
-            assertEquals(
-                UserConstants.VEILEDER_IDENT,
-                (fetchedKandidat?.status as KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet).veilederident
-            )
-            assertNull(fetchedKandidat.status.vurderingAlternativ)
-            assertNotNull(fetchedKandidat.status.publishedAt)
-
-            val producerRecordSlot = mutableListOf<ProducerRecord<String, KartleggingssporsmalKandidatStatusRecord>>()
-            verify(exactly = 2) { mockKandidatProducer.send(capture(producerRecordSlot)) }
-
-            val lastRecord = producerRecordSlot.last().value()
-            assertEquals(createdKandidat.uuid, lastRecord.kandidatUuid)
-            assertEquals(ARBEIDSTAKER_PERSONIDENT.value, lastRecord.personident)
-            assertEquals(KandidatStatus.FERDIGBEHANDLET.name, lastRecord.status)
-            assertEquals(Skjemavariant.FLERVALG_V1.name, lastRecord.skjemavariant)
-        }
 
         @Test
         fun `registrer ferdig behandlet with vurderingAlternativ should store status, veilederident and vurderingAlternativ`() = runTest {

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatTest.kt
@@ -1,8 +1,8 @@
 package no.nav.syfo.kartleggingssporsmal.domain
 
 import no.nav.syfo.UserConstants
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import java.time.OffsetDateTime
 import kotlin.test.assertTrue
@@ -42,7 +42,7 @@ class KartleggingssporsmalKandidatTest {
 
         val ferdigbehandletKandidat = svarMottattKandidat.ferdigbehandleVurdering(
             veilederident = UserConstants.VEILEDER_IDENT,
-            vurderingAlternativ = null,
+            vurderingAlternativ = KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
         )
 
         assertThrows<IllegalArgumentException> {
@@ -59,7 +59,7 @@ class KartleggingssporsmalKandidatTest {
         assertThrows<IllegalArgumentException> {
             newKandidat.ferdigbehandleVurdering(
                 veilederident = UserConstants.VEILEDER_IDENT,
-                vurderingAlternativ = null,
+                vurderingAlternativ = KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
             )
         }
         val svarMottattKandidat = newKandidat.registrerSvarMottatt(
@@ -67,14 +67,14 @@ class KartleggingssporsmalKandidatTest {
         )
         val ferdigbehandletKandidat = svarMottattKandidat.ferdigbehandleVurdering(
             veilederident = UserConstants.VEILEDER_IDENT,
-            vurderingAlternativ = null,
+            vurderingAlternativ = KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
         )
         assert(ferdigbehandletKandidat.status is KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet)
 
         assertThrows<IllegalArgumentException> {
             ferdigbehandletKandidat.ferdigbehandleVurdering(
                 veilederident = UserConstants.VEILEDER_IDENT,
-                vurderingAlternativ = null,
+                vurderingAlternativ = KartleggingssporsmalKandidatStatusendring.Ferdigbehandlet.VurderingAlternativ.IKKE_RISIKO_FOR_LANGTIDSFRAVAR,
             )
         }
     }


### PR DESCRIPTION
Fjerner nullable `VurderingAlternativ` ved PUT-endepunktet vårt nå som det alltid er påkrevd.

Avhenger (egentlig ikke) av [denne](https://github.com/navikt/syfomodiaperson/pull/2133).