### PR TITLE
IS-4180: Add new skjemavariant FLERVALG_V2

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalService.kt
@@ -102,7 +102,7 @@ class KartleggingssporsmalService(
                     val skjemavariant = if (enhet?.enhetId in pilotkontorerWithFritekst) {
                         Skjemavariant.FLERVALG_FRITEKST_V3
                     } else {
-                        Skjemavariant.FLERVALG_V1
+                        Skjemavariant.FLERVALG_V2
                     }
                     val kandidat = KartleggingssporsmalKandidat.create(
                         personident = stoppunkt.personident,

--- a/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidat.kt
+++ b/src/main/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidat.kt
@@ -80,6 +80,7 @@ data class KartleggingssporsmalKandidat(
 
 enum class Skjemavariant {
     FLERVALG_V1,
+    FLERVALG_V2,
     FLERVALG_FRITEKST_V1,
     FLERVALG_FRITEKST_V2,
     FLERVALG_FRITEKST_V3,

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/api/endpoints/KartleggingssporsmalEndpointsTest.kt
@@ -69,7 +69,7 @@ class KartleggingssporsmalEndpointsTest {
             val client = setupApiAndClient(kartleggingssporsmalServiceMock)
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             coEvery { kartleggingssporsmalServiceMock.getKandidatur(ARBEIDSTAKER_PERSONIDENT) } returns listOf(kandidat)
             coEvery { kartleggingssporsmalServiceMock.getKandidatStatus(kandidat.uuid) } returns listOf(kandidat.status)
@@ -159,7 +159,7 @@ class KartleggingssporsmalEndpointsTest {
                 )
             val kandidatFerdigbehandlet = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
                 .copy(status = ferdigBehandletStatus)
             val svarAt = nowUTC().minusDays(1)
@@ -204,7 +204,7 @@ class KartleggingssporsmalEndpointsTest {
         fun `Returns status Forbidden if denied write access`() = testApplication {
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             val client = setupApiAndClient(kartleggingssporsmalServiceMock)
             coEvery { kartleggingssporsmalServiceMock.getKandidat(kandidat.uuid) } returns kandidat

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/application/KartleggingssporsmalServiceTest.kt
@@ -751,7 +751,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -785,7 +785,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidatHendelse = producerRecordSlotKandidat.captured.value()
             assertEquals(kandidatHendelse.status, KandidatStatus.SVAR_MOTTATT.name)
-            assertEquals(Skjemavariant.FLERVALG_V1.name, kandidatHendelse.skjemavariant)
+            assertEquals(Skjemavariant.FLERVALG_V2.name, kandidatHendelse.skjemavariant)
 
             val esyfovarselHendelse = producerRecordSlotVarsel.captured.value()
             assertEquals(esyfovarselHendelse.type, HendelseType.SM_KARTLEGGINGSSPORSMAL)
@@ -806,7 +806,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -878,7 +878,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             ).copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -920,7 +920,7 @@ class KartleggingssporsmalServiceTest {
             assertEquals(createdKandidat.uuid, lastRecord.kandidatUuid)
             assertEquals(ARBEIDSTAKER_PERSONIDENT.value, lastRecord.personident)
             assertEquals(KandidatStatus.FERDIGBEHANDLET.name, lastRecord.status)
-            assertEquals(Skjemavariant.FLERVALG_V1.name, lastRecord.skjemavariant)
+            assertEquals(Skjemavariant.FLERVALG_V2.name, lastRecord.skjemavariant)
         }
 
         @Test
@@ -935,7 +935,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -979,7 +979,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
                 shouldSendVarsel = true,
             )
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -1015,7 +1015,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
                 shouldSendVarsel = true,
             )
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -1049,7 +1049,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
                 shouldSendVarsel = true,
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -1077,7 +1077,7 @@ class KartleggingssporsmalServiceTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
                 shouldSendVarsel = false,
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/domain/KartleggingssporsmalKandidatTest.kt
@@ -13,21 +13,21 @@ class KartleggingssporsmalKandidatTest {
     fun `new kandidat has correct status and values`() {
         val newKandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
-            skjemavariant = Skjemavariant.FLERVALG_V1,
+            skjemavariant = Skjemavariant.FLERVALG_V2,
         )
 
         assert(newKandidat.status is KartleggingssporsmalKandidatStatusendring.Kandidat)
         assertTrue(newKandidat.personident == UserConstants.ARBEIDSTAKER_PERSONIDENT)
         assertNull(newKandidat.varsletAt)
         assertNull(newKandidat.journalpostId)
-        assertTrue(newKandidat.skjemavariant == Skjemavariant.FLERVALG_V1)
+        assertTrue(newKandidat.skjemavariant == Skjemavariant.FLERVALG_V2)
     }
 
     @Test
     fun `registrereSvarMottatt only works when status is Kandidat or SvarMottatt`() {
         val newKandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
-            skjemavariant = Skjemavariant.FLERVALG_V1,
+            skjemavariant = Skjemavariant.FLERVALG_V2,
         )
 
         val svarMottattKandidat = newKandidat.registrerSvarMottatt(
@@ -54,7 +54,7 @@ class KartleggingssporsmalKandidatTest {
     fun `ferdigbehandleKandidat only works when status is SvarMottatt`() {
         val newKandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT,
-            skjemavariant = Skjemavariant.FLERVALG_V1,
+            skjemavariant = Skjemavariant.FLERVALG_V2,
         )
         assertThrows<IllegalArgumentException> {
             newKandidat.ferdigbehandleVurdering(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/cronjob/FerdigstillKartleggingssporsmalVarselCronjobTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/cronjob/FerdigstillKartleggingssporsmalVarselCronjobTest.kt
@@ -30,7 +30,7 @@ class FerdigstillKartleggingssporsmalVarselCronjobTest {
     private fun createVarsletKandidatMedSvarMottatt(): KartleggingssporsmalKandidat {
         val kandidat = KartleggingssporsmalKandidat.create(
             personident = ARBEIDSTAKER_PERSONIDENT,
-            skjemavariant = Skjemavariant.FLERVALG_V1,
+            skjemavariant = Skjemavariant.FLERVALG_V2,
         ).copy(varsletAt = OffsetDateTime.now())
         return kandidat.registrerSvarMottatt(OffsetDateTime.now())
     }

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/database/KartleggingssporsmalRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/database/KartleggingssporsmalRepositoryTest.kt
@@ -151,7 +151,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -234,11 +234,11 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             val otherKandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
                 .copy(createdAt = OffsetDateTime.now().minusHours(1))
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -273,7 +273,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -300,7 +300,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -333,11 +333,11 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             val otherKandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
                 .copy(createdAt = OffsetDateTime.now().minusHours(1))
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -373,7 +373,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
                 .copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
@@ -393,7 +393,7 @@ class KartleggingssporsmalRepositoryTest {
     fun `updateSvarForKandidat should throw an exception when the kandidat does not exist`() {
         val kandidat = KartleggingssporsmalKandidat.create(
             personident = ARBEIDSTAKER_PERSONIDENT,
-            skjemavariant = Skjemavariant.FLERVALG_V1,
+            skjemavariant = Skjemavariant.FLERVALG_V2,
         )
         val kandidatSvarMottatt = kandidat.registrerSvarMottatt(OffsetDateTime.now())
         runBlocking {
@@ -426,7 +426,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             ).copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -458,7 +458,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             ).copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -495,7 +495,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             ).copy(varsletAt = OffsetDateTime.now())
             val createdKandidat = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -526,7 +526,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             ).copy(varsletAt = OffsetDateTime.now())
             kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(
                 kandidat = kandidat,
@@ -556,7 +556,7 @@ class KartleggingssporsmalRepositoryTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
                 shouldSendVarsel = shouldSendVarsel,
             ).copy(varsletAt = varsletAt)
             val created = kartleggingssporsmalRepository.createKandidatAndMarkStoppunktAsProcessed(

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/journalforing/JournalforingServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/journalforing/JournalforingServiceTest.kt
@@ -117,7 +117,7 @@ class JournalforingServiceTest {
             pdfClientMock.createKartleggingPdf(
                 payload = PdfModel(
                     brevdata = BrevData(
-                        skjemavariant = Skjemavariant.FLERVALG_V1.name,
+                        skjemavariant = Skjemavariant.FLERVALG_V2.name,
                         createdAt = varsletKandidat.varsletAt!!.toLocalDateOslo().format(PdfModel.formatter)
                     ),
                 ),
@@ -147,7 +147,7 @@ class JournalforingServiceTest {
     fun `feiler når kall til pdl feiler`() {
         val kandidat = KartleggingssporsmalKandidat.create(
             personident = UserConstants.ARBEIDSTAKER_PERSONIDENT_PDL_FAILS,
-            skjemavariant = Skjemavariant.FLERVALG_V1,
+            skjemavariant = Skjemavariant.FLERVALG_V2,
         )
 
         val result = runBlocking {

--- a/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/EsyfovarselProducerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartleggingssporsmal/infrastructure/kafka/EsyfovarselProducerTest.kt
@@ -34,7 +34,7 @@ class EsyfovarselProducerTest {
         fun `sendKartleggingssporsmal should send varsel`() {
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
 
             val result = esyfovarselProducer.sendKartleggingssporsmal(kandidat)
@@ -59,7 +59,7 @@ class EsyfovarselProducerTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
 
             val result = esyfovarselProducer.sendKartleggingssporsmal(kandidat)
@@ -81,7 +81,7 @@ class EsyfovarselProducerTest {
         fun `ferdigstillKartleggingssporsmalVarsel should send varsel with ferdigstill flag true`() {
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
 
             val result = esyfovarselProducer.ferdigstillKartleggingssporsmalVarsel(kandidat)
@@ -106,7 +106,7 @@ class EsyfovarselProducerTest {
 
             val kandidat = KartleggingssporsmalKandidat.create(
                 personident = ARBEIDSTAKER_PERSONIDENT,
-                skjemavariant = Skjemavariant.FLERVALG_V1,
+                skjemavariant = Skjemavariant.FLERVALG_V2,
             )
             val result = esyfovarselProducer.ferdigstillKartleggingssporsmalVarsel(kandidat)
 


### PR DESCRIPTION
Alle som ikke er `pilotkontorerWithFritekst` skal nå få FLERVALG_V2 skjemaet i stedet. 
Oppdaterer alle testene også så det er på riktig versjon.

Se også PDF-endring: https://github.com/navikt/syfooppdfgen/pull/169